### PR TITLE
Collection cluster info api

### DIFF
--- a/src/api/collection.rs
+++ b/src/api/collection.rs
@@ -131,7 +131,7 @@ impl CollectionClusterInfo {
             .collect::<Vec<_>>();
 
         let mut remote_shards = vec![];
-        for (_, replic_set) in (*replica_holder).shards.iter() {
+        for (_, replic_set) in replica_holder.shards.iter() {
             for remote_shard in replic_set.remotes.iter() {
                 remote_shards.push(CollectionClusterRemoteShard {
                     peer_id: remote_shard.peer_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ pub mod args;
 pub mod consensus;
 pub mod storage;
 
+use crate::api::collection::get_collection_cluster_info;
 use crate::consensus::Consensus;
 use crate::consensus::ConsensusState;
 use crate::{
@@ -41,6 +42,7 @@ async fn start_http_server(
             .service(get_cluster)
             .service(add_peer)
             .service(get_collections)
+            .service(get_collection_cluster_info)
             .service(get_collection)
             .service(create_collection)
             .service(upsert_points)
@@ -75,7 +77,6 @@ async fn start_p2p_server(
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     let args = parse_args();
-    println!("Starting node with url: {}", args.url);
 
     // Create a dedicated thread for internal gRPC service while we also run Actix Web server
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/src/storage/content_manager.rs
+++ b/src/storage/content_manager.rs
@@ -99,7 +99,7 @@ impl ReplicaHolder {
             .get(&shard_id)
             .ok_or_else(|| StorageError::BadInput(format!("Shard {shard_id} not found")))?;
 
-        return Ok(&replica_set.local);
+        Ok(&replica_set.local)
     }
 
     pub fn select_shards(
@@ -439,9 +439,12 @@ mod tests {
     async fn test_shard_routing() {
         let tmp_dir = tempfile::tempdir().unwrap();
 
+        let s0 = LocalShard::init(tmp_dir.path().join("0"), 0);
+        let s1 = LocalShard::init(tmp_dir.path().join("1"), 1);
+
         let shard_holder = ReplicaHolder::new(HashMap::from_iter([
-            (0, LocalShard::init(tmp_dir.path().join("0"), 0)),
-            (1, LocalShard::init(tmp_dir.path().join("1"), 1)),
+            (0, ReplicaSet::new(s0, vec![])),
+            (1, ReplicaSet::new(s1, vec![])),
         ]));
 
         let shards_to_point_ids = shard_holder

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -111,4 +111,8 @@ impl Segment {
         }
         Ok(points)
     }
+
+    pub fn count_points(&self) -> usize {
+        self.db.len()
+    }
 }

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -89,4 +89,12 @@ impl LocalShard {
             ))
         }
     }
+
+    pub fn count_points(&self) -> usize {
+        if let Some(segment) = self.segments.get(&0) {
+            segment.count_points()
+        } else {
+            0
+        }
+    }
 }


### PR DESCRIPTION
Also introduces the concept of local and remote shards.

Rename `ShardHolder` to `ReplicaHolder` and respective changes in other places.