### PR TITLE
Get points cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /storage
 flamegraph.svg
 perf.data
+/cluster

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,12 +817,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -830,6 +846,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "futures-sink"
@@ -849,10 +893,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -2213,6 +2263,7 @@ dependencies = [
  "actix-web",
  "clap",
  "criterion",
+ "futures",
  "hashring",
  "http 1.3.1",
  "prost 0.11.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tempfile = "3.20.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.1", features = ["full"] }
 rand = "0.9.1"
+futures = "0.3.31"
 
 [build-dependencies]
 tonic-build = "0.13.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=xx / /
 # so, please, don't reorder them without prior consideration. 🥲
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y clang lld \
+    && apt-get install --no-install-recommends -y clang lld protobuf-compiler libprotobuf-dev \
     && rustup component add rustfmt
 
 # `ARG`/`ENV` pair is a workaround for `docker build` backward-compatibility.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,0 +1,5 @@
+
+
+- https://www.perplexity.ai/search/difference-between-pathbuf-and-iE73jVGRR3SH1g9R2srYeQ `PathBuf.to_owned()`
+- https://claude.ai/chat/9f4b59ad-6aa5-4304-9473-8a523227aaed -> `impl From<&Collection> for CollectionInfo`
+- https://www.perplexity.ai/search/hashmap-vs-ahashmap-rust-hQH5FiNCTg2bJWg7.KGJ2g -> didn't really use AHashMap yet tho. Will check perf later. iirc, tim added this wherever he could.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,52 +3,28 @@ version: "3.7"
 services:
   smoldb-0:
     image: kshivendu/smoldb:latest
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
-    environment:
-      - QDRANT__SERVICE__GRPC_PORT=6334
-      - QDRANT__CLUSTER__ENABLED=true
-      - QDRANT__CLUSTER__RESHARDING_ENABLED=true
-      - QDRANT__CLUSTER__P2P__PORT=6335
     ports:
-      - "9900:9900"
-      - "9910:9910"
+      - "9001:9900"
+      - "5001:9920"
     entrypoint: []
-    command: ./smoldb --url 'smoldb-0:9900'
+    command: ./smoldb
 
   smoldb-1:
     image: kshivendu/smoldb:latest
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
-    environment:
-      - QDRANT__SERVICE__GRPC_PORT=6334
-      - QDRANT__CLUSTER__ENABLED=true
-      - QDRANT__CLUSTER__RESHARDING_ENABLED=true
-      - QDRANT__CLUSTER__P2P__PORT=6335
     depends_on:
       - smoldb-0
     ports:
-      - "9901:9900"
-      - "9911:9910"
+      - "9002:9900"
+      - "5002:9920"
     entrypoint: []
-    command: bash -c "sleep 5 && ./smoldb --bootstrap 'smoldb-0:9900' --url 'smoldb-1:9900'"
+    command: sh -c "sleep 5 && ./smoldb --bootstrap 'http://smoldb-0:9900'" # this http:// part is important for bootstrap (might eventually fix)
 
   smoldb-2:
     image: kshivendu/smoldb:latest
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
-    environment:
-      - QDRANT__SERVICE__GRPC_PORT=6334
-      - QDRANT__CLUSTER__ENABLED=true
-      - QDRANT__CLUSTER__RESHARDING_ENABLED=true
-      - QDRANT__CLUSTER__P2P__PORT=6335
     depends_on:
       - smoldb-0
     ports:
-      - "9902:9900"
-      - "9912:9910"
+      - "9003:9900"
+      - "5003:9920"
     entrypoint: []
-    command: bash -c "sleep 6 && ./smoldb --bootstrap 'smoldb-0:9900' --url 'smoldb-2:9900'"
+    command: sh -c "sleep 6 && ./smoldb --bootstrap 'http://smoldb-0:9900'"

--- a/src/api/collection.rs
+++ b/src/api/collection.rs
@@ -1,19 +1,15 @@
 use crate::consensus::{ConsensusState, PeerId, Persistent};
 use crate::storage::content_manager::{
-    Collection, CollectionConfig, CollectionInfo, CollectionMetaOperation, ReplicaHolder,
-    TableOfContent,
+    Collection, CollectionInfo, CollectionMetaOperation, TableOfContent,
 };
 use crate::storage::shard::ShardId;
 use actix_web::{
     web::{self, Json},
     Responder,
 };
-use http::Uri;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::str::FromStr;
-use std::{collections::HashMap, sync::Arc};
-use tokio::sync::RwLock;
+use std::sync::Arc;
 
 // Router that decides if query should go through ToC or consensus
 pub struct Dispatcher {
@@ -22,9 +18,9 @@ pub struct Dispatcher {
 }
 
 impl Dispatcher {
-    pub fn from(toc: TableOfContent, consensus_state: Option<Arc<ConsensusState>>) -> Self {
+    pub fn from(toc: Arc<TableOfContent>, consensus_state: Option<Arc<ConsensusState>>) -> Self {
         Dispatcher {
-            toc: Arc::new(toc),
+            toc,
             consensus_state,
         }
     }
@@ -34,25 +30,6 @@ impl Dispatcher {
             Some(consensus_state.persistent.read().await.clone())
         } else {
             None
-        }
-    }
-
-    pub fn dummy() -> Self {
-        Dispatcher {
-            toc: Arc::new(TableOfContent::from(HashMap::from_iter([(
-                "c1".to_string(),
-                Collection {
-                    id: "c1".to_string(),
-                    config: CollectionConfig {
-                        params: "dummy_params".to_string(),
-                    },
-                    replica_holder: Arc::new(RwLock::new(ReplicaHolder::dummy())),
-                    path: "dummy_path".into(),
-                },
-            )]))),
-            consensus_state: Some(Arc::new(ConsensusState::dummy(
-                Uri::from_str("http://smoldb-dummy:9900").unwrap(),
-            ))),
         }
     }
 }

--- a/src/api/grpc/points_service.rs
+++ b/src/api/grpc/points_service.rs
@@ -1,0 +1,104 @@
+use std::{collections::HashMap, sync::Arc};
+
+use tonic::{async_trait, Response};
+
+use crate::{
+    api::grpc::smoldb_p2p_grpc::{
+        points_internal_server::PointsInternal, GetPointsRequest, GetPointsResponse, Point,
+        PointsOperationResponseInternal, UpsertPointsInternal,
+    },
+    storage::{content_manager::TableOfContent, segment::PointId},
+};
+
+pub struct PointsInternalService {
+    toc: Arc<TableOfContent>,
+}
+
+impl PointsInternalService {
+    pub fn new(toc: Arc<TableOfContent>) -> Self {
+        PointsInternalService { toc }
+    }
+}
+
+#[async_trait]
+impl PointsInternal for PointsInternalService {
+    async fn get_points(
+        &self,
+        request: tonic::Request<GetPointsRequest>,
+    ) -> Result<Response<GetPointsResponse>, tonic::Status> {
+        let request: GetPointsRequest = request.into_inner();
+        let collection_name = request.collection_name;
+
+        println!(
+            "Received internal request to get points from collection: {}",
+            collection_name
+        );
+
+        let collections = self.toc.collections.read().await;
+        let collection = collections.get(&collection_name).ok_or_else(|| {
+            tonic::Status::not_found(format!("Collection '{}' not found", collection_name))
+        })?;
+
+        let point_ids = if request.return_all {
+            None
+        } else {
+            Some(
+                request
+                    .ids
+                    .into_iter()
+                    .map(|id| PointId::Id(id))
+                    .collect::<Vec<_>>(),
+            )
+        };
+
+        let points = collection
+            .get_points(point_ids, request.shard_id, true)
+            .await;
+
+        let points = points.map_err(|e| {
+            tonic::Status::internal(format!(
+                "Failed to retrieve points from collection '{}': {}",
+                collection_name, e
+            ))
+        })?;
+
+        Ok(Response::new(GetPointsResponse {
+            points: points
+                .into_iter()
+                .filter_map(|p| {
+                    if let PointId::Id(id) = p.id {
+                        // FixMe: This is a workaround for not being able to pass json just yet.
+                        let payload = p
+                            .payload
+                            .as_object()
+                            .and_then(|hashmap| {
+                                Some(
+                                    hashmap
+                                        .into_iter()
+                                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                                        .collect::<HashMap<_, _>>(),
+                                )
+                            })
+                            .unwrap();
+
+                        return Some(Point {
+                            id,
+                            payload: payload,
+                        });
+                    }
+                    None // ignore UUIDs for now
+                })
+                .collect(),
+        }))
+    }
+
+    async fn upsert(
+        &self,
+        _request: tonic::Request<UpsertPointsInternal>,
+    ) -> Result<Response<PointsOperationResponseInternal>, tonic::Status> {
+        // This is a stub implementation. Replace with actual logic to upsert points.
+        Ok(Response::new(PointsOperationResponseInternal {
+            message: "Upsert operation completed".to_string(),
+        }))
+    }
+}

--- a/src/api/grpc/raft_service.rs
+++ b/src/api/grpc/raft_service.rs
@@ -4,6 +4,7 @@ use crate::{
         RaftMessage as RaftMessageBytes, Uri,
     },
     consensus::{self, ConsensusState},
+    storage::content_manager::TableOfContent,
 };
 use prost_for_raft::Message as ProtocolBufferMessage; // this trait is required for .decode() to work
 use raft::eraftpb::Message as RaftMessageParsed;
@@ -12,16 +13,19 @@ use tonic::{Request, Response, Status};
 
 pub struct RaftService {
     sender: Sender<consensus::Msg>,
+    toc: Arc<TableOfContent>,
     consensus_state: Option<Arc<ConsensusState>>,
 }
 
 impl RaftService {
     pub fn new(
         sender: Sender<consensus::Msg>,
+        toc: Arc<TableOfContent>,
         consensus_state: Option<Arc<ConsensusState>>,
     ) -> Self {
         RaftService {
             sender,
+            toc,
             consensus_state,
         }
     }
@@ -77,6 +81,20 @@ impl Raft for RaftService {
             .add_peer(request.id, uri)
             .await
             .map_err(|e| Status::internal(format!("Failed to add peer: {e}")))?;
+
+        let collections_guard = self.toc.collections.write().await;
+        for (collection_name, collection) in collections_guard.iter() {
+            let mut replica_holder_guard = collection.replica_holder.write().await;
+            replica_holder_guard
+                .add_remote_shards(request.id, collection_name.clone())
+                .await
+                .map_err(|e| {
+                    Status::internal(format!(
+                        "Failed to add remote shards for collection '{}': {e}",
+                        collection_name
+                    ))
+                })?;
+        }
 
         let persistent = consensus_state.persistent.read().await.clone();
 

--- a/src/api/grpc/raft_service.rs
+++ b/src/api/grpc/raft_service.rs
@@ -90,8 +90,7 @@ impl Raft for RaftService {
                 .await
                 .map_err(|e| {
                     Status::internal(format!(
-                        "Failed to add remote shards for collection '{}': {e}",
-                        collection_name
+                        "Failed to add remote shards for collection '{collection_name}': {e}",
                     ))
                 })?;
         }

--- a/src/api/grpc/smoldb_p2p_grpc.rs
+++ b/src/api/grpc/smoldb_p2p_grpc.rs
@@ -46,6 +46,44 @@ pub struct Uri {
     #[prost(string, tag = "1")]
     pub uri: ::prost::alloc::string::String,
 }
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct UpsertPointsInternal {
+    #[prost(uint32, optional, tag = "2")]
+    pub shard_id: ::core::option::Option<u32>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PointsOperationResponseInternal {
+    #[prost(string, tag = "1")]
+    pub message: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPointsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub points: ::prost::alloc::vec::Vec<Point>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPointsRequest {
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+    #[prost(uint64, repeated, tag = "2")]
+    pub ids: ::prost::alloc::vec::Vec<u64>,
+    /// If true, return all points in the collection
+    #[prost(bool, tag = "3")]
+    pub return_all: bool,
+    #[prost(uint32, optional, tag = "4")]
+    pub shard_id: ::core::option::Option<u32>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Point {
+    #[prost(uint64, tag = "1")]
+    pub id: u64,
+    /// limiting the payload type for now
+    #[prost(map = "string, string", tag = "2")]
+    pub payload: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
+}
 /// Generated client implementations.
 pub mod service_client {
     #![allow(
@@ -318,6 +356,147 @@ pub mod raft_client {
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("smoldb_p2p_grpc.Raft", "AddPeerToKnown"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated client implementations.
+pub mod points_internal_client {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct PointsInternalClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl PointsInternalClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> PointsInternalClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::Body>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> PointsInternalClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+        {
+            PointsInternalClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        pub async fn get_points(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetPointsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetPointsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/smoldb_p2p_grpc.PointsInternal/GetPoints",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("smoldb_p2p_grpc.PointsInternal", "GetPoints"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn upsert(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpsertPointsInternal>,
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponseInternal>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/smoldb_p2p_grpc.PointsInternal/Upsert",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("smoldb_p2p_grpc.PointsInternal", "Upsert"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -776,6 +955,240 @@ pub mod raft_server {
     /// Generated gRPC service name
     pub const SERVICE_NAME: &str = "smoldb_p2p_grpc.Raft";
     impl<T> tonic::server::NamedService for RaftServer<T> {
+        const NAME: &'static str = SERVICE_NAME;
+    }
+}
+/// Generated server implementations.
+pub mod points_internal_server {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with PointsInternalServer.
+    #[async_trait]
+    pub trait PointsInternal: std::marker::Send + std::marker::Sync + 'static {
+        async fn get_points(
+            &self,
+            request: tonic::Request<super::GetPointsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetPointsResponse>,
+            tonic::Status,
+        >;
+        async fn upsert(
+            &self,
+            request: tonic::Request<super::UpsertPointsInternal>,
+        ) -> std::result::Result<
+            tonic::Response<super::PointsOperationResponseInternal>,
+            tonic::Status,
+        >;
+    }
+    #[derive(Debug)]
+    pub struct PointsInternalServer<T> {
+        inner: Arc<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    impl<T> PointsInternalServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for PointsInternalServer<T>
+    where
+        T: PointsInternal,
+        B: Body + std::marker::Send + 'static,
+        B::Error: Into<StdError> + std::marker::Send + 'static,
+    {
+        type Response = http::Response<tonic::body::Body>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            match req.uri().path() {
+                "/smoldb_p2p_grpc.PointsInternal/GetPoints" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetPointsSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::GetPointsRequest>
+                    for GetPointsSvc<T> {
+                        type Response = super::GetPointsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetPointsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as PointsInternal>::get_points(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetPointsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/smoldb_p2p_grpc.PointsInternal/Upsert" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpsertSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::UpsertPointsInternal>
+                    for UpsertSvc<T> {
+                        type Response = super::PointsOperationResponseInternal;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UpsertPointsInternal>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as PointsInternal>::upsert(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = UpsertSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(
+                            tonic::body::Body::default(),
+                        );
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
+            }
+        }
+    }
+    impl<T> Clone for PointsInternalServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    /// Generated gRPC service name
+    pub const SERVICE_NAME: &str = "smoldb_p2p_grpc.PointsInternal";
+    impl<T> tonic::server::NamedService for PointsInternalServer<T> {
         const NAME: &'static str = SERVICE_NAME;
     }
 }

--- a/src/api/points.rs
+++ b/src/api/points.rs
@@ -57,7 +57,7 @@ async fn get_point(
 
     let result = dispatcher
         .toc
-        .retrieve_points(&collection_name, Some(&[point_id]))
+        .retrieve_points(&collection_name, Some(vec![point_id]))
         .await;
 
     match result {

--- a/src/args.rs
+++ b/src/args.rs
@@ -13,6 +13,9 @@ pub struct Args {
     /// Url of the node
     #[clap(short, long, default_value = "http://0.0.0.0:9920")]
     pub p2p_url: Uri,
+    /// Peer id
+    #[clap(long)]
+    pub peer_id: Option<u64>,
 }
 
 pub fn parse_args() -> Args {

--- a/src/channel_service.rs
+++ b/src/channel_service.rs
@@ -38,7 +38,7 @@ impl Default for TransportChannelPool {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct ChannelService {
     /// Shared with consensus state
     pub id_to_address: Arc<RwLock<HashMap<PeerId, Uri>>>,
@@ -46,10 +46,10 @@ pub struct ChannelService {
 }
 
 impl ChannelService {
-    pub fn new() -> Self {
-        ChannelService {
-            id_to_address: Default::default(),
-            channel_pool: Default::default(),
+    pub fn new(id_to_address: Arc<RwLock<HashMap<PeerId, Uri>>>) -> Self {
+        Self {
+            id_to_address,
+            channel_pool: Arc::new(TransportChannelPool::default()),
         }
     }
 }

--- a/src/channel_service.rs
+++ b/src/channel_service.rs
@@ -1,0 +1,55 @@
+use std::{collections::HashMap, sync::Arc};
+
+use http::Uri;
+use tokio::sync::RwLock;
+use tonic::transport::{Channel, Error as TonicError};
+
+use crate::{api::grpc::make_default_grpc_channel, consensus::PeerId};
+
+/// Holds a pool of channels established for a set of URIs.
+/// Channel are shared by cloning them.
+/// Make the `pool_size` larger to increase throughput.
+pub struct TransportChannelPool {
+    uri_to_channel: tokio::sync::RwLock<HashMap<Uri, Channel>>,
+}
+
+impl TransportChannelPool {
+    pub async fn get_or_create_channel(&self, uri: Uri) -> Result<Channel, TonicError> {
+        let uri_to_channel_guard = self.uri_to_channel.read().await;
+
+        if uri_to_channel_guard.contains_key(&uri) {
+            return Ok(uri_to_channel_guard.get(&uri).unwrap().clone());
+        }
+
+        drop(uri_to_channel_guard); // Explicitly drop the read lock before acquiring a write lock
+        let mut uri_to_channel_guard = self.uri_to_channel.write().await;
+        let channel = make_default_grpc_channel(uri.clone()).await?;
+        uri_to_channel_guard.insert(uri.clone(), channel.clone());
+
+        Ok(channel)
+    }
+}
+
+impl Default for TransportChannelPool {
+    fn default() -> Self {
+        Self {
+            uri_to_channel: tokio::sync::RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ChannelService {
+    /// Shared with consensus state
+    pub id_to_address: Arc<RwLock<HashMap<PeerId, Uri>>>,
+    pub channel_pool: Arc<TransportChannelPool>,
+}
+
+impl ChannelService {
+    pub fn new() -> Self {
+        ChannelService {
+            id_to_address: Default::default(),
+            channel_pool: Default::default(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
 pub mod args;
+pub mod channel_service;
 pub mod consensus;
 pub mod storage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,10 +91,7 @@ async fn main() -> std::io::Result<()> {
 
     let consensus_async_runtime = rt.handle().clone();
 
-    let consensus_state = Arc::new(ConsensusState::dummy(
-        args.p2p_url.clone(),
-        args.peer_id.clone(),
-    ));
+    let consensus_state = Arc::new(ConsensusState::dummy(args.p2p_url.clone(), args.peer_id));
 
     let sender = Consensus::start(
         args.bootstrap.clone(),
@@ -105,10 +102,8 @@ async fn main() -> std::io::Result<()> {
 
     let consensus_app_data = web::Data::from(Arc::new(ConsensusAppData::new(sender.clone())));
 
-    let mut channel_service = ChannelService::new();
-
     // Sharing the Arc<RwLock<HashMap<PeerId, Uri>>>
-    channel_service.id_to_address = consensus_state.peer_address_by_id.clone();
+    let channel_service = ChannelService::new(consensus_state.peer_address_by_id.clone());
 
     let toc = TableOfContent::load(channel_service);
     let toc_arc = Arc::new(toc);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 pub mod api;
 pub mod args;
+pub mod channel_service;
 pub mod consensus;
 pub mod storage;
 
 use crate::api::collection::get_collection_cluster_info;
+use crate::channel_service::ChannelService;
 use crate::consensus::Consensus;
 use crate::consensus::ConsensusState;
 use crate::{
@@ -59,6 +61,7 @@ async fn start_http_server(
 // Function to start the Tonic internal (p2p) gRPC server
 async fn start_p2p_server(
     p2p_uri: Uri,
+    toc: Arc<TableOfContent>,
     msg_sender: Sender<Msg>,
     consensus_state: Option<Arc<ConsensusState>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -67,7 +70,7 @@ async fn start_p2p_server(
 
     println!("Starting internal gRPC server on {p2p_host}:{p2p_port}");
 
-    if let Err(e) = api::grpc::init(p2p_host, p2p_port, msg_sender, consensus_state).await {
+    if let Err(e) = api::grpc::init(p2p_host, p2p_port, toc, msg_sender, consensus_state).await {
         eprintln!("Failed to start gRPC server: {e}");
     }
 
@@ -88,7 +91,10 @@ async fn main() -> std::io::Result<()> {
 
     let consensus_async_runtime = rt.handle().clone();
 
-    let consensus_state = Arc::new(ConsensusState::dummy(args.p2p_url.clone()));
+    let consensus_state = Arc::new(ConsensusState::dummy(
+        args.p2p_url.clone(),
+        args.peer_id.clone(),
+    ));
 
     let sender = Consensus::start(
         args.bootstrap.clone(),
@@ -99,10 +105,16 @@ async fn main() -> std::io::Result<()> {
 
     let consensus_app_data = web::Data::from(Arc::new(ConsensusAppData::new(sender.clone())));
 
-    let toc = TableOfContent::load();
+    let mut channel_service = ChannelService::new();
+
+    // Sharing the Arc<RwLock<HashMap<PeerId, Uri>>>
+    channel_service.id_to_address = consensus_state.peer_address_by_id.clone();
+
+    let toc = TableOfContent::load(channel_service);
+    let toc_arc = Arc::new(toc);
 
     let dispatcher_app_data = web::Data::from(Arc::new(Dispatcher::from(
-        toc,
+        toc_arc.clone(),
         Some(consensus_state.clone()),
     )));
 
@@ -123,7 +135,7 @@ async fn main() -> std::io::Result<()> {
     let p2p_handle = std::thread::spawn(move || {
         rt_p2p.block_on(async {
             if let Err(e) =
-                start_p2p_server(args.p2p_url, sender_to_move, Some(consensus_state)).await
+                start_p2p_server(args.p2p_url, toc_arc, sender_to_move, Some(consensus_state)).await
             {
                 eprintln!("gRPC Server error: {e}");
             }

--- a/src/proto/root_api.proto
+++ b/src/proto/root_api.proto
@@ -59,3 +59,35 @@ message PeerId {
 message Uri {
   string uri = 1;
 }
+
+
+// Internal points service for syncing data between peers:
+
+service PointsInternal {
+  rpc GetPoints (GetPointsRequest) returns (GetPointsResponse) {}
+  rpc Upsert (UpsertPointsInternal) returns (PointsOperationResponseInternal) {}
+}
+
+message UpsertPointsInternal {
+  optional uint32 shard_id = 2;
+}
+
+message PointsOperationResponseInternal {
+  string message = 1;
+}
+
+message GetPointsResponse {
+  repeated Point points = 1;
+}
+
+message GetPointsRequest {
+  string collection_name = 1;
+  repeated uint64 ids = 2;
+  bool return_all = 3; // If true, return all points in the collection
+  optional uint32 shard_id = 4;
+}
+
+message Point {
+  uint64 id = 1;
+  map<string, string> payload = 2; // limiting the payload type for now
+}

--- a/src/storage/content_manager.rs
+++ b/src/storage/content_manager.rs
@@ -214,7 +214,7 @@ impl Collection {
 
         if let Some(shard_id) = shard_id {
             let replica_set = replica_holder.get_replica_set(shard_id).await?;
-            return Ok(replica_set.local.get_points(Some(ids))?);
+            Ok(replica_set.local.get_points(Some(ids))?)
         } else {
             let mut points = vec![];
 
@@ -225,8 +225,8 @@ impl Collection {
                 points.extend(collected_points);
             }
 
-            return Ok(points);
-        };
+            Ok(points)
+        }
     }
 }
 

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -7,3 +7,17 @@ pub enum StorageError {
     #[error("Service error: {0}")]
     ServiceError(String),
 }
+
+#[derive(Error, Debug)]
+pub enum CollectionError {
+    #[error("Tonic transport error: {0}")]
+    TonicTransportError(#[from] tonic::transport::Error),
+    #[error("Tonic error: {0}")]
+    TonicStatusError(#[from] tonic::Status),
+    #[error("Service error: {0}")]
+    ServiceError(String),
+    #[error("Storage error: {0}")]
+    StorageError(#[from] StorageError),
+}
+
+pub type CollectionResult<T> = Result<T, CollectionError>;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,6 @@
 pub mod content_manager;
 pub mod error;
+pub mod replicas;
 pub mod segment;
 pub mod shard;
+pub mod shard_trait;

--- a/src/storage/replicas.rs
+++ b/src/storage/replicas.rs
@@ -107,7 +107,7 @@ impl ShardOperationTrait for RemoteShard {
         //     "Remote shard get_points not implemented".to_string(),
         // ))
 
-        let mut channel_service = ChannelService::new(); // Replace with actual channel service instance
+        let mut channel_service = ChannelService::default(); // Replace with actual channel service instance
 
         // let current_node_uri = http::Uri::from_str("http://localhost:50051").unwrap();
 
@@ -169,7 +169,7 @@ impl ShardOperationTrait for RemoteShard {
     async fn update(&self, _wait: bool) -> CollectionResult<UpdateResult> {
         Ok(UpdateResult {
             // Placeholder for actual operation ID logic
-            operation_id: Some(0 as u64),
+            operation_id: Some(0_u64),
         })
     }
 }
@@ -257,7 +257,7 @@ impl ReplicaHolder {
             .get(&shard_id)
             .ok_or_else(|| StorageError::BadInput(format!("Shard {shard_id} not found")))?;
 
-        Ok(&replica_set)
+        Ok(replica_set)
     }
 
     // Wrong abstraction: but add remote shards for a given collection in each of the shards.

--- a/src/storage/replicas.rs
+++ b/src/storage/replicas.rs
@@ -1,0 +1,304 @@
+use crate::{
+    api::grpc::smoldb_p2p_grpc::{
+        points_internal_client::PointsInternalClient, GetPointsRequest, UpsertPointsInternal,
+    },
+    channel_service::ChannelService,
+    consensus::PeerId,
+    storage::{
+        content_manager::CollectionName,
+        error::{CollectionError, CollectionResult, StorageError},
+        segment::{Point, PointId},
+        shard::{LocalShard, ShardId},
+        shard_trait::{ShardOperationTrait, UpdateResult},
+    },
+};
+use futures::future::BoxFuture;
+use std::{collections::HashMap, future::Future, str::FromStr, sync::Arc};
+use tokio::sync::RwLock;
+use tonic::{async_trait, transport::Channel, Request, Status};
+
+pub struct RemoteShard {
+    pub id: ShardId,
+    pub collection: CollectionName,
+    pub peer_id: PeerId,
+}
+
+impl RemoteShard {
+    /// Init a remote shard in memory that can be used to communicate with replicas on a remote peer.
+    pub fn new(id: ShardId, collection: CollectionName, peer_id: PeerId) -> Self {
+        RemoteShard {
+            id,
+            collection,
+            peer_id,
+        }
+    }
+
+    async fn current_address(
+        &self,
+        channel_service: &ChannelService,
+    ) -> CollectionResult<http::Uri> {
+        let guard_peer_addresses = channel_service.id_to_address.read().await;
+        let peer_address = guard_peer_addresses.get(&self.peer_id).cloned();
+
+        println!(
+            "Remote shard {}:{} has address {:?}",
+            self.peer_id, self.id, peer_address
+        );
+
+        match peer_address {
+            Some(uri) => Ok(uri),
+            None => Err(CollectionError::ServiceError(format!(
+                "Peer {} does not have an address in the channel service",
+                self.peer_id
+            ))),
+        }
+    }
+
+    async fn with_points_client<T, O: Future<Output = Result<T, Status>>>(
+        &self,
+        channel_service: ChannelService,
+        f: impl Fn(PointsInternalClient<Channel>) -> O,
+    ) -> CollectionResult<T> {
+        let uri = self.current_address(&channel_service).await?;
+
+        let channel = channel_service
+            .channel_pool
+            .get_or_create_channel(uri)
+            .await?;
+
+        let points_channel: PointsInternalClient<Channel> = PointsInternalClient::new(channel);
+
+        f(points_channel).await.map_err(|e| {
+            CollectionError::ServiceError(format!(
+                "Failed to execute operation on remote shard {}: {}",
+                self.id, e
+            ))
+        })
+    }
+
+    pub async fn upsert(&self, channel_service: ChannelService) -> Result<(), CollectionError> {
+        let uri = self.current_address(&channel_service).await?;
+
+        let channel = channel_service
+            .channel_pool
+            .get_or_create_channel(uri)
+            .await?;
+
+        let mut points_channel = PointsInternalClient::new(channel);
+
+        let res = points_channel
+            .upsert(tonic::Request::new(UpsertPointsInternal {
+                shard_id: Some(self.id),
+            }))
+            .await?
+            .into_inner();
+
+        println!("Response from remote shard {}: {:?}", self.id, res);
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ShardOperationTrait for RemoteShard {
+    async fn get_points(&self, ids: Option<Vec<PointId>>) -> CollectionResult<Vec<Point>> {
+        // Placeholder for actual remote shard logic
+        // Err(CollectionError::ServiceError(
+        //     "Remote shard get_points not implemented".to_string(),
+        // ))
+
+        let mut channel_service = ChannelService::new(); // Replace with actual channel service instance
+
+        // let current_node_uri = http::Uri::from_str("http://localhost:50051").unwrap();
+
+        let inner_map: HashMap<_, _> = HashMap::from_iter(vec![
+            // (self.peer_id, current_node_uri),
+            (101, http::Uri::from_str("http://0.0.0.0:5001").unwrap()),
+            (102, http::Uri::from_str("http://0.0.0.0:5002").unwrap()),
+            (103, http::Uri::from_str("http://0.0.0.0:5003").unwrap()),
+        ]);
+        channel_service.id_to_address = Arc::new(RwLock::new(inner_map));
+
+        let return_all = ids.is_none();
+        let ids = ids.unwrap_or_default();
+
+        let ids = ids
+            .into_iter()
+            .filter_map(|id| {
+                if let PointId::Id(id) = id {
+                    Some(id)
+                } else {
+                    None // Skip non-ID point IDs
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let get_points_response = self
+            .with_points_client(channel_service, |mut client| {
+                println!(
+                    "Calling PointsInternalClient::get_points on remote shard {}:{}",
+                    self.peer_id, self.id
+                );
+                let ids = ids.clone();
+                async move {
+                    let request = Request::new(GetPointsRequest {
+                        collection_name: self.collection.clone(),
+                        ids,
+                        return_all,
+                        shard_id: Some(self.id), // Ask the other node to return points only for this shard
+                    });
+
+                    client.get_points(request).await
+                }
+            })
+            .await?
+            .into_inner();
+
+        let points = get_points_response
+            .points
+            .into_iter()
+            .map(|p| Point {
+                id: PointId::Id(p.id),
+                payload: p.payload.into_iter().collect(),
+            })
+            .collect::<Vec<_>>();
+
+        Ok(points)
+    }
+
+    async fn update(&self, _wait: bool) -> CollectionResult<UpdateResult> {
+        Ok(UpdateResult {
+            // Placeholder for actual operation ID logic
+            operation_id: Some(0 as u64),
+        })
+    }
+}
+
+pub struct ReplicaSet {
+    pub local: LocalShard,
+    pub remotes: Vec<RemoteShard>,
+
+    #[allow(dead_code)]
+    collection_id: CollectionName,
+}
+
+impl ReplicaSet {
+    pub fn new(local: LocalShard, remotes: Vec<PeerId>, collection_id: CollectionName) -> Self {
+        let remotes = remotes
+            .into_iter()
+            .map(|peer_id| RemoteShard::new(local.id, collection_id.clone(), peer_id))
+            .collect();
+
+        ReplicaSet {
+            local,
+            remotes,
+            collection_id,
+        }
+    }
+
+    pub async fn execute_cluster_read_operation<Res, F>(
+        &self,
+        read_operation: F,
+        local_only: bool,
+    ) -> CollectionResult<Vec<Res>>
+    where
+        F: Fn(&(dyn ShardOperationTrait + Send + Sync)) -> BoxFuture<'_, CollectionResult<Res>>,
+    {
+        let local_result = read_operation(&self.local).await?;
+        let mut final_results = vec![local_result];
+
+        if local_only {
+            return Ok(final_results);
+        }
+
+        for remote in &self.remotes {
+            let operation_result = read_operation(remote).await;
+            match operation_result {
+                Ok(res) => final_results.push(res),
+                Err(e) => {
+                    // Ignore errors from remote shards, but log them
+                    println!(
+                        "Error executing operation on remote shard {}/{}: {}",
+                        remote.peer_id, remote.id, e
+                    );
+                }
+            }
+        }
+
+        Ok(final_results)
+    }
+}
+
+pub struct ReplicaHolder {
+    pub shards: HashMap<ShardId, ReplicaSet>,
+    ring: hashring::HashRing<ShardId>,
+}
+
+impl ReplicaHolder {
+    pub fn new(shards: HashMap<ShardId, ReplicaSet>) -> Self {
+        let mut ring = hashring::HashRing::new();
+        for shard_id in shards.keys() {
+            ring.add(*shard_id);
+        }
+
+        ReplicaHolder { shards, ring }
+    }
+
+    pub fn dummy() -> Self {
+        ReplicaHolder {
+            shards: HashMap::new(),
+            ring: hashring::HashRing::new(),
+        }
+    }
+
+    pub async fn get_replica_set(&self, shard_id: ShardId) -> Result<&ReplicaSet, StorageError> {
+        let replica_set = self
+            .shards
+            .get(&shard_id)
+            .ok_or_else(|| StorageError::BadInput(format!("Shard {shard_id} not found")))?;
+
+        Ok(&replica_set)
+    }
+
+    // Wrong abstraction: but add remote shards for a given collection in each of the shards.
+    pub async fn add_remote_shards(
+        &mut self,
+        peer_id: PeerId,
+        collection: CollectionName,
+    ) -> Result<(), StorageError> {
+        for (shard_id, replica_set) in self.shards.iter_mut() {
+            // Add if not exists
+            if replica_set.remotes.iter().any(|r| r.peer_id == peer_id) {
+                continue; // Skip if remote shard already exists
+            }
+
+            replica_set
+                .remotes
+                .push(RemoteShard::new(*shard_id, collection.clone(), peer_id));
+        }
+
+        // ToDo: What happens to hashring if shard already exists when you add?
+        // self.ring.add(shard_id);
+
+        Ok(())
+    }
+
+    pub fn select_shards(
+        &self,
+        point_ids: &[PointId],
+    ) -> Result<HashMap<ShardId, Vec<PointId>>, StorageError> {
+        let mut shards_to_point_ids = HashMap::new();
+        for point_id in point_ids {
+            let shard_id = self
+                .ring
+                .get(&point_id)
+                .ok_or_else(|| StorageError::ServiceError("No shards found".to_string()))?;
+
+            shards_to_point_ids
+                .entry(*shard_id)
+                .or_insert_with(Vec::new)
+                .push(point_id.clone());
+        }
+        Ok(shards_to_point_ids)
+    }
+}

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -74,7 +74,7 @@ impl Segment {
         Ok(())
     }
 
-    pub fn get_points(&self, ids: Option<&[PointId]>) -> Result<Vec<Point>, StorageError> {
+    pub fn get_points(&self, ids: Option<Vec<PointId>>) -> Result<Vec<Point>, StorageError> {
         let mut points = Vec::new();
 
         let Some(ids) = ids else {

--- a/src/storage/shard_trait.rs
+++ b/src/storage/shard_trait.rs
@@ -1,0 +1,17 @@
+use tonic::async_trait;
+
+use crate::storage::{
+    error::CollectionResult,
+    segment::{Point, PointId},
+};
+
+#[derive(Copy, Clone, Debug)]
+pub struct UpdateResult {
+    pub operation_id: Option<u64>,
+}
+
+#[async_trait]
+pub trait ShardOperationTrait {
+    async fn get_points(&self, ids: Option<Vec<PointId>>) -> CollectionResult<Vec<Point>>;
+    async fn update(&self, wait: bool) -> CollectionResult<UpdateResult>;
+}

--- a/tools/setup_cluster.sh
+++ b/tools/setup_cluster.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+smoldb="./target/debug/smoldb"
+
+smoldb -u 127.0.0.1:9900
+smoldb -u 127.0.0.1:9900


### PR DESCRIPTION
Now whenever you add a node to an existing cluster (by using `--bootstrap`), smoldb will create `RemoteShard` entries to that peer's replicas for each of the collection and will try to query them when you call `GET collections/test_collection/points` on the first node (ideally each node should be able to query all other replicas but that needs some more effort)