### PR TITLE
Cluster level upsert

### DIFF
--- a/benches/read_write.rs
+++ b/benches/read_write.rs
@@ -38,7 +38,7 @@ pub fn single_write(c: &mut Criterion) {
 
     group.bench_function("single_write", |b| {
         b.to_async(&rt).iter(|| async {
-            collection.insert_points(&points).await.unwrap();
+            collection.upsert_points(&points, true).await.unwrap();
         })
     });
 }
@@ -85,7 +85,10 @@ pub fn concurrent_write(c: &mut Criterion) {
             for chunk in points.chunks(chunk_size) {
                 let collection_clone = collection_arc.clone();
                 let chunk_clone = chunk.to_vec();
-                collection_clone.insert_points(&chunk_clone).await.unwrap();
+                collection_clone
+                    .upsert_points(&chunk_clone, true)
+                    .await
+                    .unwrap();
             }
         })
     });
@@ -120,7 +123,7 @@ pub fn single_read(c: &mut Criterion) {
             payload: json!({ "msg": "Hello world" }),
         }];
 
-        collection.insert_points(&points).await.unwrap();
+        collection.upsert_points(&points).await.unwrap();
 
         collection
     });
@@ -170,7 +173,7 @@ fn concurrent_read(c: &mut Criterion) {
         .await
         .unwrap();
 
-        collection.insert_points(&points).await.unwrap();
+        collection.upsert_points(&points).await.unwrap();
 
         collection
     });

--- a/benches/read_write.rs
+++ b/benches/read_write.rs
@@ -123,7 +123,7 @@ pub fn single_read(c: &mut Criterion) {
             payload: json!({ "msg": "Hello world" }),
         }];
 
-        collection.upsert_points(&points).await.unwrap();
+        collection.upsert_points(&points, true).await.unwrap();
 
         collection
     });
@@ -173,7 +173,7 @@ fn concurrent_read(c: &mut Criterion) {
         .await
         .unwrap();
 
-        collection.upsert_points(&points).await.unwrap();
+        collection.upsert_points(&points, true).await.unwrap();
 
         collection
     });

--- a/src/api/grpc/points_service.rs
+++ b/src/api/grpc/points_service.rs
@@ -1,9 +1,12 @@
 use crate::{
     api::grpc::smoldb_p2p_grpc::{
-        points_internal_server::PointsInternal, GetPointsRequest, GetPointsResponse, Point,
-        PointsOperationResponseInternal, UpsertPointsInternal,
+        points_internal_server::PointsInternal, GetPointsRequest, GetPointsResponse,
+        Point as GrpcPoint, UpsertPointsRequest, UpsertPointsResponse,
     },
-    storage::{content_manager::TableOfContent, segment::PointId},
+    storage::{
+        content_manager::TableOfContent,
+        segment::{Point, PointId},
+    },
 };
 use std::sync::Arc;
 use tonic::{async_trait, Response};
@@ -24,28 +27,27 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: tonic::Request<GetPointsRequest>,
     ) -> Result<Response<GetPointsResponse>, tonic::Status> {
-        let request: GetPointsRequest = request.into_inner();
-        let collection_name = request.collection_name;
+        let GetPointsRequest {
+            collection_name,
+            ids,
+            return_all,
+            shard_id,
+        } = request.into_inner();
 
-        println!(
-            "Received internal request to get points from collection: {}",
-            collection_name
-        );
+        println!("Received internal request to get points from collection: {collection_name}");
 
         let collections = self.toc.collections.read().await;
         let collection = collections.get(&collection_name).ok_or_else(|| {
             tonic::Status::not_found(format!("Collection '{collection_name}' not found"))
         })?;
 
-        let point_ids = if request.return_all {
+        let point_ids = if return_all {
             None
         } else {
-            Some(request.ids.into_iter().map(PointId::Id).collect::<Vec<_>>())
+            Some(ids.into_iter().map(PointId::Id).collect::<Vec<_>>())
         };
 
-        let points = collection
-            .get_points(point_ids, request.shard_id, true)
-            .await;
+        let points = collection.get_points(point_ids, shard_id, true).await;
 
         let points = points.map_err(|e| {
             tonic::Status::internal(format!(
@@ -60,7 +62,7 @@ impl PointsInternal for PointsInternalService {
                     if let PointId::Id(id) = p.id {
                         // FixMe: This is a workaround for not being able to pass json just yet.
                         let payload = p.payload.to_string();
-                        return Some(Point { id, payload });
+                        return Some(GrpcPoint { id, payload });
                     }
                     None // ignore UUIDs for now
                 })
@@ -68,12 +70,37 @@ impl PointsInternal for PointsInternalService {
         }))
     }
 
-    async fn upsert(
+    async fn upsert_points(
         &self,
-        _request: tonic::Request<UpsertPointsInternal>,
-    ) -> Result<Response<PointsOperationResponseInternal>, tonic::Status> {
-        // This is a stub implementation. Replace with actual logic to upsert points.
-        Ok(Response::new(PointsOperationResponseInternal {
+        _request: tonic::Request<UpsertPointsRequest>,
+    ) -> Result<Response<UpsertPointsResponse>, tonic::Status> {
+        let UpsertPointsRequest {
+            collection_name,
+            points,
+            shard_id: _, // ToDo: We should specify shard_id when upserting?
+        } = _request.into_inner();
+        println!("Received internal request to upsert points from collection: {collection_name}");
+
+        let collections = self.toc.collections.read().await;
+        let collection = collections.get(&collection_name).ok_or_else(|| {
+            tonic::Status::not_found(format!("Collection '{collection_name}' not found"))
+        })?;
+
+        let points = points
+            .into_iter()
+            .map(|p| Point {
+                id: PointId::Id(p.id),
+                payload: serde_json::from_str(&p.payload).unwrap(),
+            })
+            .collect::<Vec<_>>();
+
+        collection.upsert_points(&points, true).await.map_err(|e| {
+            tonic::Status::internal(format!(
+                "Failed to upsert points in collection '{collection_name}': {e}"
+            ))
+        })?;
+
+        Ok(Response::new(UpsertPointsResponse {
             message: "Upsert operation completed".to_string(),
         }))
     }

--- a/src/api/grpc/smoldb_p2p_grpc.rs
+++ b/src/api/grpc/smoldb_p2p_grpc.rs
@@ -46,13 +46,17 @@ pub struct Uri {
     #[prost(string, tag = "1")]
     pub uri: ::prost::alloc::string::String,
 }
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct UpsertPointsInternal {
-    #[prost(uint32, optional, tag = "2")]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpsertPointsRequest {
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag = "2")]
+    pub points: ::prost::alloc::vec::Vec<Point>,
+    #[prost(uint32, optional, tag = "3")]
     pub shard_id: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PointsOperationResponseInternal {
+pub struct UpsertPointsResponse {
     #[prost(string, tag = "1")]
     pub message: ::prost::alloc::string::String,
 }
@@ -472,11 +476,11 @@ pub mod points_internal_client {
                 .insert(GrpcMethod::new("smoldb_p2p_grpc.PointsInternal", "GetPoints"));
             self.inner.unary(req, path, codec).await
         }
-        pub async fn upsert(
+        pub async fn upsert_points(
             &mut self,
-            request: impl tonic::IntoRequest<super::UpsertPointsInternal>,
+            request: impl tonic::IntoRequest<super::UpsertPointsRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponseInternal>,
+            tonic::Response<super::UpsertPointsResponse>,
             tonic::Status,
         > {
             self.inner
@@ -489,11 +493,13 @@ pub mod points_internal_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/smoldb_p2p_grpc.PointsInternal/Upsert",
+                "/smoldb_p2p_grpc.PointsInternal/UpsertPoints",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("smoldb_p2p_grpc.PointsInternal", "Upsert"));
+                .insert(
+                    GrpcMethod::new("smoldb_p2p_grpc.PointsInternal", "UpsertPoints"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -975,11 +981,11 @@ pub mod points_internal_server {
             tonic::Response<super::GetPointsResponse>,
             tonic::Status,
         >;
-        async fn upsert(
+        async fn upsert_points(
             &self,
-            request: tonic::Request<super::UpsertPointsInternal>,
+            request: tonic::Request<super::UpsertPointsRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::PointsOperationResponseInternal>,
+            tonic::Response<super::UpsertPointsResponse>,
             tonic::Status,
         >;
     }
@@ -1104,25 +1110,25 @@ pub mod points_internal_server {
                     };
                     Box::pin(fut)
                 }
-                "/smoldb_p2p_grpc.PointsInternal/Upsert" => {
+                "/smoldb_p2p_grpc.PointsInternal/UpsertPoints" => {
                     #[allow(non_camel_case_types)]
-                    struct UpsertSvc<T: PointsInternal>(pub Arc<T>);
+                    struct UpsertPointsSvc<T: PointsInternal>(pub Arc<T>);
                     impl<
                         T: PointsInternal,
-                    > tonic::server::UnaryService<super::UpsertPointsInternal>
-                    for UpsertSvc<T> {
-                        type Response = super::PointsOperationResponseInternal;
+                    > tonic::server::UnaryService<super::UpsertPointsRequest>
+                    for UpsertPointsSvc<T> {
+                        type Response = super::UpsertPointsResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::UpsertPointsInternal>,
+                            request: tonic::Request<super::UpsertPointsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PointsInternal>::upsert(&inner, request).await
+                                <T as PointsInternal>::upsert_points(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1133,7 +1139,7 @@ pub mod points_internal_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = UpsertSvc(inner);
+                        let method = UpsertPointsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/src/proto/root_api.proto
+++ b/src/proto/root_api.proto
@@ -65,14 +65,16 @@ message Uri {
 
 service PointsInternal {
   rpc GetPoints (GetPointsRequest) returns (GetPointsResponse) {}
-  rpc Upsert (UpsertPointsInternal) returns (PointsOperationResponseInternal) {}
+  rpc UpsertPoints (UpsertPointsRequest) returns (UpsertPointsResponse) {}
 }
 
-message UpsertPointsInternal {
-  optional uint32 shard_id = 2;
+message UpsertPointsRequest {
+  string collection_name = 1;
+  repeated Point points = 2;
+  optional uint32 shard_id = 3;
 }
 
-message PointsOperationResponseInternal {
+message UpsertPointsResponse {
   string message = 1;
 }
 

--- a/src/storage/content_manager.rs
+++ b/src/storage/content_manager.rs
@@ -94,6 +94,8 @@ impl Collection {
             })
             .collect::<Result<HashMap<_, _>, StorageError>>()?;
 
+        // ToDo: Add remote shards to replica holder while creating a new collection?
+
         Ok(Collection {
             id,
             config,

--- a/src/storage/content_manager.rs
+++ b/src/storage/content_manager.rs
@@ -2,10 +2,11 @@ use crate::{
     api::points::PointsOperation,
     channel_service::ChannelService,
     storage::{
-        error::{CollectionError, StorageError},
+        error::{CollectionResult, StorageError},
         replicas::{ReplicaHolder, ReplicaSet},
         segment::{Point, PointId},
         shard::{LocalShard, ShardId},
+        shard_trait::ShardOperationTrait,
     },
 };
 use futures::FutureExt;
@@ -151,7 +152,7 @@ impl Collection {
         })
     }
 
-    pub async fn insert_points(&self, points: &[Point]) -> Result<(), StorageError> {
+    pub async fn upsert_points(&self, points: &[Point], local_only: bool) -> CollectionResult<()> {
         let shard_holder = &self.replica_holder.read().await;
 
         let points_map: HashMap<PointId, Point> = points
@@ -173,7 +174,17 @@ impl Collection {
                 .filter_map(|id| points_map.get(id).cloned())
                 .collect::<Vec<_>>();
 
-            replica_set.local.insert_points(&points)?
+            let _ = replica_set
+                .execute_cluster_read_operation(
+                    |shard| {
+                        let points_cloned = points.clone();
+                        async move { shard.upsert_points(points_cloned).await }.boxed()
+                    },
+                    local_only,
+                )
+                .await?;
+
+            // replica_set.local.insert_points(&points)?
         }
 
         Ok(())
@@ -184,7 +195,7 @@ impl Collection {
         ids: Option<Vec<PointId>>,
         shard_id: Option<ShardId>,
         local_only: bool,
-    ) -> Result<Vec<Point>, CollectionError> {
+    ) -> CollectionResult<Vec<Point>> {
         let replica_holder = self.replica_holder.read().await;
 
         let Some(ids) = ids else {
@@ -214,14 +225,14 @@ impl Collection {
 
         if let Some(shard_id) = shard_id {
             let replica_set = replica_holder.get_replica_set(shard_id).await?;
-            Ok(replica_set.local.get_points(Some(ids))?)
+            Ok(replica_set.local.get_points(Some(ids)).await?)
         } else {
             let mut points = vec![];
 
             for (shard_id, shard_point_ids) in replica_holder.select_shards(&ids)? {
                 let replica_set = replica_holder.get_replica_set(shard_id).await?;
 
-                let collected_points = replica_set.local.get_points(Some(shard_point_ids))?;
+                let collected_points = replica_set.local.get_points(Some(shard_point_ids)).await?;
                 points.extend(collected_points);
             }
 
@@ -368,7 +379,7 @@ impl TableOfContent {
         match operation {
             PointsOperation::Upsert(upsert_points) => {
                 collection
-                    .insert_points(&upsert_points.points)
+                    .upsert_points(&upsert_points.points, false)
                     .await
                     .map_err(|e| {
                         StorageError::ServiceError(format!(

--- a/src/storage/content_manager.rs
+++ b/src/storage/content_manager.rs
@@ -175,7 +175,7 @@ impl Collection {
                 .collect::<Vec<_>>();
 
             let _ = replica_set
-                .execute_cluster_read_operation(
+                .execute_cluster_operation(
                     |shard| {
                         let points_cloned = points.clone();
                         async move { shard.upsert_points(points_cloned).await }.boxed()
@@ -183,8 +183,6 @@ impl Collection {
                     local_only,
                 )
                 .await?;
-
-            // replica_set.local.insert_points(&points)?
         }
 
         Ok(())
@@ -209,7 +207,7 @@ impl Collection {
                 }
 
                 let replica_results = replica_set
-                    .execute_cluster_read_operation(
+                    .execute_cluster_operation(
                         |shard| {
                             let ids_cloned = ids.clone();
                             async move { shard.get_points(ids_cloned).await }.boxed()

--- a/src/storage/replicas.rs
+++ b/src/storage/replicas.rs
@@ -201,6 +201,8 @@ impl ReplicaSet {
         }
     }
 
+    /// Executes the operation on the local shard and then on all the remote shards.
+    /// If `local_only` is true, it only executes on the local shard.
     pub async fn execute_cluster_operation<Res, F>(
         &self,
         operation: F,

--- a/src/storage/replicas.rs
+++ b/src/storage/replicas.rs
@@ -201,15 +201,15 @@ impl ReplicaSet {
         }
     }
 
-    pub async fn execute_cluster_read_operation<Res, F>(
+    pub async fn execute_cluster_operation<Res, F>(
         &self,
-        read_operation: F,
+        operation: F,
         local_only: bool,
     ) -> CollectionResult<Vec<Res>>
     where
         F: Fn(&(dyn ShardOperationTrait + Send + Sync)) -> BoxFuture<'_, CollectionResult<Res>>,
     {
-        let local_result = read_operation(&self.local).await?;
+        let local_result = operation(&self.local).await?;
         let mut final_results = vec![local_result];
 
         if local_only {
@@ -217,7 +217,7 @@ impl ReplicaSet {
         }
 
         for remote in &self.remotes {
-            let operation_result = read_operation(remote).await;
+            let operation_result = operation(remote).await;
             match operation_result {
                 Ok(res) => final_results.push(res),
                 Err(e) => {

--- a/src/storage/replicas.rs
+++ b/src/storage/replicas.rs
@@ -1,6 +1,7 @@
 use crate::{
     api::grpc::smoldb_p2p_grpc::{
-        points_internal_client::PointsInternalClient, GetPointsRequest, UpsertPointsInternal,
+        points_internal_client::PointsInternalClient, GetPointsRequest, Point as PointGrpc,
+        UpsertPointsRequest,
     },
     channel_service::ChannelService,
     consensus::PeerId,
@@ -9,7 +10,7 @@ use crate::{
         error::{CollectionError, CollectionResult, StorageError},
         segment::{Point, PointId},
         shard::{LocalShard, ShardId},
-        shard_trait::{ShardOperationTrait, UpdateResult},
+        shard_trait::ShardOperationTrait,
     },
 };
 use futures::future::BoxFuture;
@@ -76,49 +77,23 @@ impl RemoteShard {
         })
     }
 
-    pub async fn upsert(&self, channel_service: ChannelService) -> Result<(), CollectionError> {
-        let uri = self.current_address(&channel_service).await?;
-
-        let channel = channel_service
-            .channel_pool
-            .get_or_create_channel(uri)
-            .await?;
-
-        let mut points_channel = PointsInternalClient::new(channel);
-
-        let res = points_channel
-            .upsert(tonic::Request::new(UpsertPointsInternal {
-                shard_id: Some(self.id),
-            }))
-            .await?
-            .into_inner();
-
-        println!("Response from remote shard {}: {:?}", self.id, res);
-
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl ShardOperationTrait for RemoteShard {
-    async fn get_points(&self, ids: Option<Vec<PointId>>) -> CollectionResult<Vec<Point>> {
-        // Placeholder for actual remote shard logic
-        // Err(CollectionError::ServiceError(
-        //     "Remote shard get_points not implemented".to_string(),
-        // ))
-
-        let mut channel_service = ChannelService::default(); // Replace with actual channel service instance
-
-        // let current_node_uri = http::Uri::from_str("http://localhost:50051").unwrap();
+    pub fn get_channel_service(&self) -> ChannelService {
+        let mut channel_service = ChannelService::default();
 
         let inner_map: HashMap<_, _> = HashMap::from_iter(vec![
-            // (self.peer_id, current_node_uri),
             (101, http::Uri::from_str("http://0.0.0.0:5001").unwrap()),
             (102, http::Uri::from_str("http://0.0.0.0:5002").unwrap()),
             (103, http::Uri::from_str("http://0.0.0.0:5003").unwrap()),
         ]);
         channel_service.id_to_address = Arc::new(RwLock::new(inner_map));
 
+        channel_service
+    }
+}
+
+#[async_trait]
+impl ShardOperationTrait for RemoteShard {
+    async fn get_points(&self, ids: Option<Vec<PointId>>) -> CollectionResult<Vec<Point>> {
         let return_all = ids.is_none();
         let ids = ids.unwrap_or_default();
 
@@ -132,6 +107,8 @@ impl ShardOperationTrait for RemoteShard {
                 }
             })
             .collect::<Vec<_>>();
+
+        let channel_service = self.get_channel_service();
 
         let get_points_response = self
             .with_points_client(channel_service, |mut client| {
@@ -166,11 +143,39 @@ impl ShardOperationTrait for RemoteShard {
         Ok(points)
     }
 
-    async fn update(&self, _wait: bool) -> CollectionResult<UpdateResult> {
-        Ok(UpdateResult {
-            // Placeholder for actual operation ID logic
-            operation_id: Some(0_u64),
-        })
+    async fn upsert_points(&self, points: Vec<Point>) -> CollectionResult<()> {
+        let channel_service = self.get_channel_service();
+
+        let _upsert_points_response = self
+            .with_points_client(channel_service, |mut client| {
+                let points = points.clone();
+                async move {
+                    client
+                        .upsert_points(Request::new(UpsertPointsRequest {
+                            collection_name: self.collection.clone(),
+                            shard_id: None,
+                            points: points
+                                .into_iter()
+                                .filter_map(|p| {
+                                    if let PointId::Id(p_id) = p.id {
+                                        // Only include points with PointId::Id
+                                        Some(PointGrpc {
+                                            id: p_id,
+                                            payload: p.payload.to_string(),
+                                        })
+                                    } else {
+                                        None // Skip UUIDs for now
+                                    }
+                                })
+                                .collect(),
+                        }))
+                        .await
+                }
+            })
+            .await?
+            .into_inner();
+
+        Ok(()) // Placeholder for actual remote shard logic
     }
 }
 

--- a/src/storage/shard.rs
+++ b/src/storage/shard.rs
@@ -100,18 +100,6 @@ impl LocalShard {
         })
     }
 
-    // pub fn insert_points(&self, points: &[Point]) -> Result<(), StorageError> {}
-
-    // pub fn get_points(&self, ids: Option<Vec<PointId>>) -> Result<Vec<Point>, StorageError> {
-    //     if let Some(segment) = self.segments.get(&0) {
-    //         segment.get_points(ids)
-    //     } else {
-    //         Err(StorageError::ServiceError(
-    //             "No segments available".to_string(),
-    //         ))
-    //     }
-    // }
-
     pub fn count_points(&self) -> usize {
         if let Some(segment) = self.segments.get(&0) {
             segment.count_points()

--- a/src/storage/shard_trait.rs
+++ b/src/storage/shard_trait.rs
@@ -13,5 +13,5 @@ pub struct UpdateResult {
 #[async_trait]
 pub trait ShardOperationTrait {
     async fn get_points(&self, ids: Option<Vec<PointId>>) -> CollectionResult<Vec<Point>>;
-    async fn update(&self, wait: bool) -> CollectionResult<UpdateResult>;
+    async fn upsert_points(&self, points: Vec<Point>) -> CollectionResult<()>;
 }


### PR DESCRIPTION
This means now whenever you write data to shard, it will also forward the writes to its remote replicas.

Note that if remote shards are down, they'll miss the update. This will require WAL or snapshot recovery of such replicas which will be implemented in future.  

However, for now, you'll have to restart the nodes for `replica_holder.add_remote_shards(...)` to be called. Currently, it's not called on creating a collection so upserts aren't forwarded immediately after creating the collection. Restart is required. Will be fixed in future PRs.