### PR TITLE
smolbench: Report upsert server latencies

### DIFF
--- a/smolbench/src/apis.rs
+++ b/smolbench/src/apis.rs
@@ -1,0 +1,79 @@
+use crate::error::SmolBenchError;
+use crate::types::{ApiResponse, ApiSuccessResponse, Point};
+use http::Uri;
+use serde_json::{json, Value};
+
+pub async fn create_collection(
+    url: &Uri,
+    collection_name: &str,
+) -> Result<ApiSuccessResponse<Value>, SmolBenchError> {
+    let client = reqwest::Client::new();
+
+    let res = client
+        .put(format!("{url}/collections/{collection_name}"))
+        .json(&serde_json::json!({
+            "params": "..."
+        }))
+        .send()
+        .await?;
+
+    let body: ApiResponse<Value> = res.json().await?;
+
+    match body {
+        ApiResponse::Success(body) => {
+            dbg!(&body.result);
+            Ok(body)
+        }
+        ApiResponse::Error(res) => Err(SmolBenchError::CreateCollectionError(res.error)),
+    }
+}
+
+pub async fn upsert_points(
+    url: &Uri,
+    collection_name: &str,
+    num_points: usize,
+    batch_size: usize,
+) -> Result<Vec<ApiSuccessResponse<Value>>, SmolBenchError> {
+    let client = reqwest::Client::new();
+    let num_batches = num_points.div_ceil(batch_size);
+
+    let mut results = Vec::with_capacity(num_batches);
+
+    for batch in 0..num_batches {
+        let start = batch * batch_size;
+        let end = std::cmp::min(start + batch_size, num_points);
+
+        let batch_ts = chrono::Utc::now();
+
+        let points: Vec<Point> = (start..end)
+            .map(|i| Point {
+                id: i,
+                payload: json!({
+                    "text": format!("Point {}", i),
+                    "timestamp": batch_ts.to_rfc3339(),
+                }),
+            })
+            .collect();
+
+        let res = client
+            .put(format!("{url}/collections/{collection_name}/points"))
+            .json(&json!({
+                "points": points,
+            }))
+            .send()
+            .await?;
+
+        let text = res.text().await?;
+
+        let body: ApiResponse<Value> = serde_json::from_str(&text)?;
+
+        match body {
+            ApiResponse::Success(body) => results.push(body),
+            ApiResponse::Error(res) => {
+                return Err(SmolBenchError::CreateCollectionError(res.error));
+            }
+        }
+    }
+
+    Ok(results)
+}


### PR DESCRIPTION
When running normally (both smoldb & smolbench in debug profile):
```console
➜  cargo run -p smolbench 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/smolbench`
[smolbench/src/apis.rs:24:13] &body.result = Bool(true)
Collection created successfully.
Avg batch server latency: 25.79 ms
Min batch server latency: 19.13 ms
Max batch server latency: 31.69 ms
Upserted 100000 points in batches of 1000 into collection 'test'
```

When running against release build of smoldb:

```console
➜  cargo run -p smolbench -r # note: even smolbench is running release version                                                                                       

Ignoring error while creating collection: Failed to create collection: Storage error: Bad input: Collection path already exists: storage/collections/test
Avg batch server latency: 4.86 ms
Min batch server latency: 3.41 ms
Max batch server latency: 8.21 ms
Upserted 100000 points in batches of 1000 into collection 'test'
```