### PR TITLE
smolbench: Allow querying the cluster after upsert

### DIFF
--- a/smolbench/src/apis.rs
+++ b/smolbench/src/apis.rs
@@ -1,5 +1,5 @@
 use crate::error::SmolBenchError;
-use crate::types::{ApiResponse, ApiSuccessResponse, Point};
+use crate::types::{ApiResponse, ApiSuccessResponse, Point, PointId, Points};
 use http::Uri;
 use serde_json::{json, Value};
 
@@ -76,4 +76,26 @@ pub async fn upsert_points(
     }
 
     Ok(results)
+}
+
+/// Scroll through all points in a collection by pagination?
+/// ToDo: Implement pagination logic in smoldb APIs
+pub async fn retrieve_points(
+    url: &Uri,
+    collection_name: &str,
+    _ids: Option<Vec<PointId>>, // ToDo: Use this parameter to filter points
+) -> Result<ApiSuccessResponse<Points>, SmolBenchError> {
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{url}/collections/{collection_name}/points"))
+        .send()
+        .await?;
+
+    let body: ApiResponse<Points> = res.json().await?;
+
+    match body {
+        ApiResponse::Success(body) => Ok(body),
+        ApiResponse::Error(res) => Err(SmolBenchError::RetrievePointsError(res.error)),
+    }
 }

--- a/smolbench/src/args.rs
+++ b/smolbench/src/args.rs
@@ -36,7 +36,7 @@ pub struct Args {
     pub uri: Uri,
 
     /// Name of the collection
-    #[clap(short, long, default_value = "test")]
+    #[clap(short, long, default_value = "benchmark")]
     pub collection_name: String,
 
     /// Number of points to upload
@@ -46,6 +46,10 @@ pub struct Args {
     /// Batch size for upsert operations
     #[clap(short, long, default_value = "1000", value_parser = parse_number)]
     pub batch_size: usize,
+
+    /// Check whether to query after upsert
+    #[clap(short, long, default_value = "true")]
+    pub query: bool,
 }
 
 pub fn parse_args() -> Args {
@@ -64,7 +68,7 @@ mod tests {
         assert_eq!(parse_number("1B").unwrap(), 1_000_000_000);
 
         // Error cases:
-        assert!(parse_number("1kB").is_err());
+        assert!(parse_number("1K").is_err());
         assert!(parse_number("1b").is_err());
     }
 }

--- a/smolbench/src/args.rs
+++ b/smolbench/src/args.rs
@@ -48,7 +48,7 @@ pub struct Args {
     pub batch_size: usize,
 
     /// Check whether to query after upsert
-    #[clap(short, long, default_value = "true")]
+    #[clap(short, long, default_value = "false")]
     pub query: bool,
 }
 

--- a/smolbench/src/error.rs
+++ b/smolbench/src/error.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum SmolBenchError {
     #[error("Failed to create collection: {0}")]
     CreateCollectionError(String),
+    #[error("Failed to create collection: {0}")]
+    RetrievePointsError(String),
     #[error("Request error: {0}")]
     RequestError(#[from] reqwest::Error),
     #[error("JSON parsing error: {0}")]

--- a/smolbench/src/types.rs
+++ b/smolbench/src/types.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 type ResponseTime = f64;
+pub type PointId = u64;
 
 #[derive(Deserialize)]
 pub struct ApiSuccessResponse<T> {
@@ -21,8 +22,13 @@ pub enum ApiResponse<T> {
     Error(ApiErrorResponse),
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct Point {
     pub id: usize,
     pub payload: serde_json::Value,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Points {
+    pub points: Vec<Point>,
 }

--- a/smolbench/src/utils.rs
+++ b/smolbench/src/utils.rs
@@ -1,0 +1,21 @@
+use crate::{error::SmolBenchError, types::ApiSuccessResponse};
+
+pub async fn log_latencies<T>(
+    batch_responses: &[ApiSuccessResponse<T>],
+) -> Result<(), SmolBenchError> {
+    let latencies = batch_responses
+        .iter()
+        .map(|res| res.time * 1000.0) // Convert s to ms
+        .map(|latency| latency as f64)
+        .collect::<Vec<_>>();
+
+    let avg_latency = latencies.iter().sum::<f64>() / latencies.len() as f64;
+    let min_latency = latencies.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max_latency = latencies.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+
+    println!("Avg batch server latency: {:.2} ms", avg_latency);
+    println!("Min batch server latency: {:.2} ms", min_latency);
+    println!("Max batch server latency: {:.2} ms", max_latency);
+
+    Ok(())
+}


### PR DESCRIPTION
```console
➜  cargo run -p smolbench -- --query 
Ignoring error while creating collection: Failed to create collection: Storage error: Bad input: Collection path already exists: storage/collections/benchmark
Upserted 100000 points in batches of 1000 into collection 'benchmark':
Avg batch server latency: 16.21 ms
Min batch server latency: 13.77 ms
Max batch server latency: 42.65 ms
Retrieved 100000 points from collection 'benchmark' in 388.138647ms
```