### PR TITLE
smolbench: Add --skip-upsert and --skip-query

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,6 +17,11 @@ grpcurl -plaintext -import-path src/proto -proto root_api.proto 0.0.0.0:9920 smo
 ```sh
 cargo run -p smolbench # upserts
 cargo run -p smolbench -- -n 100k --uri http://localhost:9001 -b 1k
+
+# terminal 1 (upsert):
+cargo run -p smolbench --  --skip-query -n 100M --delay 1000 -b 100
+# terminal 2 (search):
+watch -n1 'cargo run -p smolbench --  --skip-upsert -n 100M --delay 1000 -b 100'
 ```
 
 ### Criterion / flamegraph branch

--- a/smolbench/src/args.rs
+++ b/smolbench/src/args.rs
@@ -47,9 +47,13 @@ pub struct Args {
     #[clap(short, long, default_value = "1000", value_parser = parse_number)]
     pub batch_size: usize,
 
+    /// Use if you don't want to upsert points by default
+    #[clap(long, default_value = "false")]
+    pub skip_upsert: bool,
+
     /// Check whether to query after upsert
-    #[clap(short, long, default_value = "false")]
-    pub query: bool,
+    #[clap(long, default_value = "false")]
+    pub skip_query: bool,
 
     /// Delay between requests (batches) in milliseconds
     #[clap(short, long, default_value = None, value_parser = parse_number)]

--- a/smolbench/src/main.rs
+++ b/smolbench/src/main.rs
@@ -22,23 +22,25 @@ async fn main() -> Result<(), SmolBenchError> {
         Err(e) => eprintln!("Ignoring error while creating collection: {e}"),
     }
 
-    let batch_responses = upsert_points(
-        &args.uri,
-        &args.collection_name,
-        args.num_points,
-        args.batch_size,
-        args.delay,
-    )
-    .await?;
+    if !args.skip_upsert {
+        let batch_responses = upsert_points(
+            &args.uri,
+            &args.collection_name,
+            args.num_points,
+            args.batch_size,
+            args.delay,
+        )
+        .await?;
 
-    println!(
-        "Upserted {} points in batches of {} into collection '{}':",
-        args.num_points, args.batch_size, args.collection_name
-    );
+        println!(
+            "Upserted {} points in batches of {} into collection '{}':",
+            args.num_points, args.batch_size, args.collection_name
+        );
 
-    log_latencies(&batch_responses).await?;
+        log_latencies(&batch_responses).await?;
+    }
 
-    if args.query {
+    if !args.skip_query {
         let response = retrieve_points(&args.uri, &args.collection_name, None).await?;
         println!(
             "Retrieved {} points from collection '{}' in {}ms",


### PR DESCRIPTION
Now you can have ongoing upsert and query

```sh
# terminal 1 (upsert):
cargo run -p smolbench --  --skip-query -n 100M --delay 1000 -b 100
 
# terminal 2 (search):
watch -n1 'cargo run -p smolbench --  --skip-upsert -n 100M --delay 1000 -b 100'
```