### PR TITLE
Smolbench shoud retreive single point at a time

### DIFF
--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -129,6 +129,34 @@ pub async fn upsert_points(
     Ok(results)
 }
 
+/// Retrieve points by their IDs
+pub async fn retrieve_point(
+    url: &Uri,
+    collection_name: &str,
+    ids: Vec<u64>,
+) -> Result<Vec<ApiSuccessResponse<Value>>, SmolBenchError> {
+    let client = reqwest::Client::new();
+    let mut results = Vec::with_capacity(ids.len());
+
+    for id in ids {
+        let res = client
+            .get(format!("{url}/collections/{collection_name}/points/{id}"))
+            .send()
+            .await?;
+
+        let body: ApiResponse<Value> = res.json().await?;
+
+        match body {
+            ApiResponse::Success(body) => {
+                results.push(body);
+            }
+            ApiResponse::Error(res) => Err(SmolBenchError::RetrievePointsError(res.error))?,
+        }
+    }
+
+    Ok(results)
+}
+
 /// Scroll through all points in a collection by pagination?
 /// ToDo: Implement pagination logic in smoldb APIs
 pub async fn retrieve_points(

--- a/tools/smolbench/src/utils.rs
+++ b/tools/smolbench/src/utils.rs
@@ -2,6 +2,7 @@ use crate::{error::SmolBenchError, types::ApiSuccessResponse};
 
 pub async fn log_latencies<T>(
     batch_responses: &[ApiSuccessResponse<T>],
+    for_what: &str,
 ) -> Result<(), SmolBenchError> {
     let latencies = batch_responses
         .iter()
@@ -13,9 +14,9 @@ pub async fn log_latencies<T>(
     let min_latency = latencies.iter().cloned().fold(f64::INFINITY, f64::min);
     let max_latency = latencies.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
 
-    println!("Avg batch server upsert latency: {:.2} ms", avg_latency);
-    println!("Min batch server upsert latency: {:.2} ms", min_latency);
-    println!("Max batch server upsert latency: {:.2} ms", max_latency);
+    println!("Avg batch server {for_what} latency: {avg_latency:.2} ms");
+    println!("Min batch server {for_what} latency: {min_latency:.2} ms");
+    println!("Max batch server {for_what} latency: {max_latency:.2} ms");
 
     Ok(())
 }


### PR DESCRIPTION
By default, we upsert 100K points. But we should retrieve single point at a time instead of retrieving all points in one API call. 
Like this we can query for at max 1000 points to get good enough estimation of query latency. 