### PR TITLE
smolbench: Support calculating p9* values from latencies

### DIFF
--- a/tools/smolbench/src/args.rs
+++ b/tools/smolbench/src/args.rs
@@ -63,6 +63,11 @@ pub struct Args {
     #[clap(long, default_value = "false")]
     pub skip_query: bool,
 
+    /// Number of 9 digits to show in p99* results
+    /// Defaults to 3, i.e. shows only p99
+    #[clap(long, long, default_value_t = 2, value_parser = parse_number)]
+    pub p9: usize,
+
     /// Delay between requests (batches) in milliseconds
     #[clap(short, long, default_value = None, value_parser = parse_number)]
     pub delay: Option<usize>,

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<(), SmolBenchError> {
             args.num_points, args.batch_size, args.collection_name
         );
 
-        log_latencies(&batch_responses, "upsert").await?;
+        log_latencies(&batch_responses, args.p9, "server-side batched upsert").await?;
     }
 
     if !args.skip_query {
@@ -85,7 +85,7 @@ async fn main() -> Result<(), SmolBenchError> {
             args.collection_name,
         );
 
-        log_latencies(&responses, "retrieve").await?;
+        log_latencies(&responses, args.p9, "server-side retrieve").await?;
     }
 
     Ok(())

--- a/tools/smolbench/src/utils.rs
+++ b/tools/smolbench/src/utils.rs
@@ -2,21 +2,38 @@ use crate::{error::SmolBenchError, types::ApiSuccessResponse};
 
 pub async fn log_latencies<T>(
     batch_responses: &[ApiSuccessResponse<T>],
+    p9: usize,
     for_what: &str,
 ) -> Result<(), SmolBenchError> {
-    let latencies = batch_responses
+    let mut latencies = batch_responses
         .iter()
         .map(|res| res.time * 1000.0) // Convert s to ms
         .map(|latency| latency as f64)
         .collect::<Vec<_>>();
 
-    let avg_latency = latencies.iter().sum::<f64>() / latencies.len() as f64;
-    let min_latency = latencies.iter().cloned().fold(f64::INFINITY, f64::min);
-    let max_latency = latencies.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    latencies.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
 
-    println!("Avg batch server {for_what} latency: {avg_latency:.2} ms");
-    println!("Min batch server {for_what} latency: {min_latency:.2} ms");
-    println!("Max batch server {for_what} latency: {max_latency:.2} ms");
+    let avg_latency = latencies.iter().sum::<f64>() / latencies.len() as f64;
+    let min_latency = latencies.first().unwrap();
+    let max_latency = latencies.last().unwrap();
+    let p50_latency = latencies[(latencies.len() as f32 * 0.50) as usize];
+
+    println!("Avg {for_what} latency: {avg_latency:.2} ms");
+    println!("Min {for_what} latency: {min_latency:.2} ms");
+    println!("p50 {for_what} latency: {p50_latency:.2} ms");
+
+    let p95_latency = latencies[(latencies.len() as f32 * 0.95) as usize];
+    println!("p95 {for_what} latency: {p95_latency:.2} ms");
+
+    for digits in 2..=p9 {
+        let factor = 1.0 - 1.0 * 0.1f64.powf(digits as f64);
+        let index = ((latencies.len() as f64 * factor) as usize).min(latencies.len() - 1);
+        let nines = "9".repeat(digits);
+        let time = latencies[index];
+        println!("p{} {for_what} latency: {:.2} ms", nines, time);
+    }
+
+    println!("Max {for_what} latency: {max_latency:.2} ms");
 
     Ok(())
 }


### PR DESCRIPTION
Both search and upsert now print p9* values (apart from min, max, and mean)

```
smolbench --skip-create --skip-upsert -n 1500 --uri http://0.0.0.0:9001
```

now returns:

```

```