### PR TITLE
Improve point read/write operations with cluster

### DIFF
--- a/src/api/grpc/points_service.rs
+++ b/src/api/grpc/points_service.rs
@@ -94,7 +94,7 @@ impl PointsInternal for PointsInternalService {
             })
             .collect::<Vec<_>>();
 
-        collection.upsert_points(&points, true).await.map_err(|e| {
+        collection.upsert_points(points, true).await.map_err(|e| {
             tonic::Status::internal(format!(
                 "Failed to upsert points in collection '{collection_name}': {e}"
             ))

--- a/src/api/points.rs
+++ b/src/api/points.rs
@@ -38,16 +38,11 @@ async fn upsert_points(
         let num_points = operation.points.len();
 
         // ToDo: Return Created() or BadRequest() in HttpResponse?
-        let result = dispatcher
+        let _result = dispatcher
             .toc
             .perform_points_op(&collection_name, PointsOperation::Upsert(operation))
-            .await;
+            .await?;
 
-        if let Err(e) = result {
-            return Err(CollectionError::ServiceError(format!(
-                "Failed to upsert points in collection '{collection_name}': {e}"
-            )));
-        }
         Ok(UpsertPointsResponse { num_points })
     })
     .await

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -2,7 +2,7 @@ use crate::storage::error::StorageError;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Debug)]
 #[serde(untagged)]
 pub enum PointId {
     Id(u64),

--- a/src/storage/toc.rs
+++ b/src/storage/toc.rs
@@ -153,7 +153,7 @@ impl TableOfContent {
         match operation {
             PointsOperation::Upsert(upsert_points) => {
                 collection
-                    .upsert_points(&upsert_points.points, false)
+                    .upsert_points(upsert_points.points, false)
                     .await
                     .map_err(|e| {
                         StorageError::ServiceError(format!(


### PR DESCRIPTION
Bunch of improvements for retrieve and upserts points APIs

Highlights:
- Introduce write consistency factor in `upsert_points` so we can offer stronger consistency guarantees. Although, it's not cancel safe at the moment. The writes can succeed in some nodes and won't be reverted (for now). But it atleast clearly throws error if writes don't succeed in at least `write_consistency_factor` replicas.
- Deduplicate and sort the point ids in `GET /collections/test/points` API using `BtreeMap`. Needed a BTree because:
  - need to deduplicate points across replicas
  - different shards can have point IDs in different orders but we want a consistent order for the response (hence not using hashmap)

Minor:
- Avoid `.clone()` in `upsert_points` by being more aware of move.
- Avoid repeated "Service error" error msg template from `upserts_points` API
