### PR TITLE
Simplify consensus layer with dedicated manager and error

### DIFF
--- a/src/api/cluster.rs
+++ b/src/api/cluster.rs
@@ -1,31 +1,10 @@
 use crate::{
     api::{collection::Dispatcher, helpers},
-    consensus::{ConsensusOperation, Msg},
+    consensus::ConsensusOperation,
     storage::error::CollectionError,
 };
 use actix_web::{web, HttpResponse, Responder};
 use serde_json::json;
-use std::sync::mpsc::Sender;
-
-pub struct ConsensusAppData {
-    sender: Sender<Msg>,
-}
-
-impl ConsensusAppData {
-    pub fn new(sender: Sender<Msg>) -> Self {
-        ConsensusAppData { sender }
-    }
-
-    pub fn submit_consensus_op(&self, operation: ConsensusOperation) {
-        self.sender
-            .send(Msg::Propose {
-                id: 100, // Example ID, should be replaced with actual logic
-                operation,
-                callback: Box::new(|| println!("Callback executed for adding peer")),
-            })
-            .expect("Failed to send message to consensus");
-    }
-}
 
 #[actix_web::get("/cluster")]
 async fn get_cluster(dispatcher: web::Data<Dispatcher>) -> impl Responder {
@@ -45,12 +24,14 @@ async fn get_cluster(dispatcher: web::Data<Dispatcher>) -> impl Responder {
 
 // ToDo: Drop this API?
 #[actix_web::get("/cluster/peer/add")]
-async fn add_peer(consensus: web::Data<ConsensusAppData>) -> HttpResponse {
+async fn add_peer(dispatcher: web::Data<Dispatcher>) -> HttpResponse {
     helpers::time(async {
-        consensus.submit_consensus_op(ConsensusOperation::AddPeer {
-            peer_id: 123, // Example peer ID, should be replaced with actual logic
-            uri: "http://example.com".to_string(), // Example URI, should be replaced with actual logic
-        });
+        dispatcher
+            .send_operation(ConsensusOperation::AddPeer {
+                peer_id: 123, // Example peer ID, should be replaced with actual logic
+                uri: "http://example.com".to_string(), // Example URI, should be replaced with actual logic
+            })
+            .await?;
 
         Ok(json!({
             "status": "success",

--- a/src/api/collection.rs
+++ b/src/api/collection.rs
@@ -1,7 +1,8 @@
 use crate::api::helpers;
-use crate::consensus::{ConsensusState, Persistent};
+use crate::consensus::{ConsensusOperation, Persistent};
+use crate::consensus_manager::ConsensusManager;
 use crate::storage::collection::{Collection, CollectionInfo};
-use crate::storage::error::CollectionError;
+use crate::storage::error::{CollectionError, CollectionResult, ConsensusError};
 use crate::storage::toc::{CollectionMetaOperation, TableOfContent};
 use crate::types::{PeerId, ShardId};
 use actix_web::{
@@ -10,27 +11,39 @@ use actix_web::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-
 // Router that decides if query should go through ToC or consensus
 pub struct Dispatcher {
     pub toc: Arc<TableOfContent>,
-    pub consensus_state: Option<Arc<ConsensusState>>,
+    pub consensus_manager: Option<ConsensusManager>,
 }
 
 impl Dispatcher {
-    pub fn from(toc: Arc<TableOfContent>, consensus_state: Option<Arc<ConsensusState>>) -> Self {
+    pub fn from(toc: Arc<TableOfContent>, consensus_manager: Option<ConsensusManager>) -> Self {
         Dispatcher {
             toc,
-            consensus_state,
+            consensus_manager,
         }
     }
 
     pub async fn get_cluster_info(&self) -> Option<Persistent> {
-        if let Some(consensus_state) = &self.consensus_state {
-            Some(consensus_state.persistent.read().await.clone())
+        if let Some(consensus_state) = &self.consensus_manager {
+            Some(consensus_state.get_state().persistent.read().await.clone())
         } else {
             None
         }
+    }
+
+    pub fn get_consensus_manager(&self) -> CollectionResult<&ConsensusManager> {
+        Ok(self
+            .consensus_manager
+            .as_ref()
+            .ok_or(ConsensusError::NotEnabled())?)
+    }
+
+    // Send a consensus operation to the consensus manager
+    pub async fn send_operation(&self, operation: ConsensusOperation) -> CollectionResult<()> {
+        let consensus_manager = self.get_consensus_manager()?;
+        Ok(consensus_manager.submit_consensus_op(operation).await?)
     }
 }
 

--- a/src/consensus_manager.rs
+++ b/src/consensus_manager.rs
@@ -1,0 +1,51 @@
+use crate::{
+    consensus::{ConsensusOperation, ConsensusState, Msg},
+    storage::{error::ConsensusError, toc::TableOfContent},
+};
+use std::sync::{mpsc::Sender, Arc};
+
+pub struct ConsensusManager {
+    toc: Arc<TableOfContent>,
+    state: Arc<ConsensusState>,
+    sender: Option<Sender<Msg>>,
+}
+
+impl ConsensusManager {
+    pub fn new(
+        toc: Arc<TableOfContent>,
+        state: Arc<ConsensusState>,
+        sender: Option<Sender<Msg>>,
+    ) -> Self {
+        ConsensusManager { toc, state, sender }
+    }
+
+    pub fn get_toc(&self) -> &Arc<TableOfContent> {
+        &self.toc
+    }
+
+    pub fn get_state(&self) -> &Arc<ConsensusState> {
+        &self.state
+    }
+
+    pub fn get_sender(&self) -> Result<&Sender<Msg>, ConsensusError> {
+        self.sender.as_ref().ok_or(ConsensusError::NotEnabled())
+    }
+
+    pub async fn submit_consensus_op(
+        &self,
+        operation: ConsensusOperation,
+    ) -> Result<(), ConsensusError> {
+        let sender = self.get_sender()?;
+        sender
+            .send(Msg::Propose {
+                id: 100, // Example ID, should be replaced with actual logic
+                operation,
+                callback: Box::new(|| println!("Callback executed for adding peer")),
+            })
+            .map_err(|e| {
+                ConsensusError::ServiceError(format!("Failed to send consensus operation: {e}"))
+            })?;
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod api;
 pub mod args;
 pub mod channel_service;
 pub mod consensus;
+pub mod consensus_manager;
 pub mod storage;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod args;
 pub mod channel_service;
 pub mod consensus;
+pub mod consensus_manager;
 pub mod storage;
 pub mod types;
 
@@ -10,9 +11,10 @@ use crate::api::collection::get_collection_cluster_info;
 use crate::channel_service::ChannelService;
 use crate::consensus::Consensus;
 use crate::consensus::ConsensusState;
+use crate::consensus_manager::ConsensusManager;
 use crate::{
     api::{
-        cluster::{add_peer, get_cluster, ConsensusAppData},
+        cluster::{add_peer, get_cluster},
         collection::{create_collection, get_collection, get_collections, Dispatcher},
         points::{get_point, list_points, upsert_points},
     },
@@ -30,11 +32,7 @@ use http::Uri;
 use std::sync::{mpsc::Sender, Arc};
 
 // Function to start the Actix Web server
-async fn start_http_server(
-    url: Uri,
-    consensus_app_data: Data<ConsensusAppData>,
-    dispatcher_app_data: Data<Dispatcher>,
-) -> std::io::Result<()> {
+async fn start_http_server(url: Uri, dispatcher_app_data: Data<Dispatcher>) -> std::io::Result<()> {
     println!("Starting Actix Web server on {url}");
 
     let (host, port) = (url.host().unwrap(), url.port_u16().unwrap());
@@ -53,7 +51,6 @@ async fn start_http_server(
             .service(upsert_points)
             .service(get_point)
             .service(list_points)
-            .app_data(consensus_app_data.clone())
             .app_data(dispatcher_app_data.clone())
     })
     .bind((host, port))?
@@ -109,19 +106,21 @@ async fn main() -> std::io::Result<()> {
     )
     .expect("Failed to start consensus");
 
-    let consensus_app_data = web::Data::from(Arc::new(ConsensusAppData::new(sender.clone())));
+    let consensus_manager = ConsensusManager::new(
+        toc_arc.clone(),
+        consensus_state.clone(),
+        Some(sender.clone()),
+    );
 
     let dispatcher_app_data = web::Data::from(Arc::new(Dispatcher::from(
         toc_arc.clone(),
-        Some(consensus_state.clone()),
+        Some(consensus_manager),
     )));
 
     let rt_http = rt.handle().clone();
     let http_handle = std::thread::spawn(move || {
         rt_http.block_on(async {
-            if let Err(e) =
-                start_http_server(args.url, consensus_app_data, dispatcher_app_data).await
-            {
+            if let Err(e) = start_http_server(args.url, dispatcher_app_data).await {
                 eprintln!("HTTP Server error: {e}");
             }
         });

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -9,15 +9,25 @@ pub enum StorageError {
 }
 
 #[derive(Error, Debug)]
+pub enum ConsensusError {
+    #[error("Consensus is not enabled")]
+    NotEnabled(),
+    #[error("Service error: {0}")]
+    ServiceError(String),
+}
+
+#[derive(Error, Debug)]
 pub enum CollectionError {
     #[error("Tonic transport error: {0}")]
     TonicTransportError(#[from] tonic::transport::Error),
     #[error("Tonic error: {0}")]
-    TonicStatusError(#[from] tonic::Status),
+    TonicStatusError(#[from] Box<tonic::Status>), // tonic::Status is 176B and bloats the error size. so we box it
     #[error("Service error: {0}")]
     ServiceError(String),
     #[error("Storage error: {0}")]
     StorageError(#[from] StorageError),
+    #[error("Consensus error: {0}")]
+    ConsensusError(#[from] ConsensusError),
     #[error("Json parsing error: {0}")]
     JsonParseError(#[from] serde_path_to_error::Error<serde_json::Error>),
 }


### PR DESCRIPTION
- Introduce `ConsensusManager` to hold state, sender, and toc arc ref.
- Drop `ConsensusAppData` and use `ConsensusManager` via Dispatcher in APIs
- Introduce dedicated `ConsensuError`