### PR TITLE
Improve arg parsing

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,17 +1,25 @@
 use clap::Parser;
 use http::Uri;
 
+fn parse_uri(s: &str) -> Result<Uri, http::uri::InvalidUri> {
+    if s.contains("://") {
+        s.parse::<Uri>()
+    } else {
+        format!("http://{s}").parse::<Uri>()
+    }
+}
+
 #[derive(Parser)]
 #[clap(version, about)]
 pub struct Args {
     /// Url of the bootstrap node
-    #[clap(short, long)]
+    #[clap(short, long, value_parser = parse_uri)]
     pub bootstrap: Option<Uri>,
     /// Url of the node
-    #[clap(short, long, default_value = "http://0.0.0.0:9000")]
+    #[clap(short, long, default_value = "0.0.0.0:9000", value_parser = parse_uri)]
     pub url: Uri,
     /// Url of the node
-    #[clap(short, long, default_value = "http://0.0.0.0:5000")]
+    #[clap(short, long, default_value = "0.0.0.0:5000", value_parser = parse_uri)]
     pub p2p_url: Uri,
     /// Peer id
     #[clap(long)]


### PR DESCRIPTION
```sh
# before:
smoldb --url 0.0.0.0:9001 --p2p-url 0.0.0.0:5001 --bootstrap http://0.0.0.0:5000 --peer-id 101
# after:
smoldb --url 0.0.0.0:9001 --p2p-url 0.0.0.0:5001 --bootstrap 0.0.0.0:5000 --peer-id 101
```

`http://` is assumed by default. It was broken especially for the bootstrap arg. Since it internally needed `http://` to exist.