### PR TITLE
Improve docker compose setup and docker dev-ex with entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,9 +101,10 @@ RUN PKG_CONFIG="/usr/bin/$(xx-info)-pkg-config" \
     && PROFILE_DIR=$(if [ "$PROFILE" = dev ]; then echo debug; else echo $PROFILE; fi) \
     && mv "target/$(xx-cargo --print-target-triple)/$PROFILE_DIR/smoldb" /smoldb/smoldb
 
-FROM gcr.io/distroless/cc-debian12 AS smoldb
+FROM debian:12-slim AS smoldb
 
 COPY --from=builder /smoldb/smoldb /smoldb
+COPY --from=builder /smoldb/tools/entrypoint.sh /entrypoint.sh
 
 USER 0
 
@@ -111,6 +112,7 @@ ENV TZ=Etc/UTC \
     RUN_MODE=production
 
 EXPOSE 9000
+EXPOSE 5000
 
 LABEL org.opencontainers.image.title="Smol DB"
 LABEL org.opencontainers.image.description="A smol database implemented from scratch in Rust"
@@ -119,9 +121,7 @@ LABEL org.opencontainers.image.documentation="https://github.com/kshivendu/smold
 LABEL org.opencontainers.image.source="https://github.com/kshivendu/smoldb"
 LABEL org.opencontainers.image.vendor="kshivendu"
 
-ENTRYPOINT ["/smoldb"]
+ENTRYPOINT ["./entrypoint.sh"]
 
 # docker build --network=host -t kshivendu/smoldb:latest .
-# docker run -p 9000:9000 kshivendu/smoldb
-# docker run -p 9000:9000 kshivendu/smoldb
 # docker run --rm -p 9000:9000 --name smoldb kshivendu/smoldb

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,3 +125,4 @@ ENTRYPOINT ["./entrypoint.sh"]
 
 # docker build --network=host -t kshivendu/smoldb:latest .
 # docker run --rm -p 9000:9000 --name smoldb kshivendu/smoldb
+# docker run --rm -p 9000:9000 -it --name smoldb kshivendu/smoldb /bin/sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,4 +125,4 @@ ENTRYPOINT ["./entrypoint.sh"]
 
 # docker build --network=host -t kshivendu/smoldb:latest .
 # docker run --rm -p 9000:9000 --name smoldb kshivendu/smoldb
-# docker run --rm -p 9000:9000 -it --name smoldb kshivendu/smoldb /bin/sh
+# docker run --rm -p 9000:9000 -it --name smoldb kshivendu/smoldb /bin/bash

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
   smoldb-0:
     container_name: smoldb-0
     image: kshivendu/smoldb:latest
+    environment:
+      - RUST_BACKTRACE=1
     ports:
       - "9000:9000"
     command: --url smoldb-0:9000 --p2p-url smoldb-0:5000 --peer-id 100
@@ -11,6 +13,8 @@ services:
   smoldb-1:
     container_name: smoldb-1
     image: kshivendu/smoldb:latest
+    environment:
+      - RUST_BACKTRACE=1
     ports:
       - "9001:9000"
     command: sh -c "echo 'Waiting 5s' && sleep 5 && /smoldb --bootstrap smoldb-0:5000 --url smoldb-1:9000 --p2p-url smoldb-1:5000  --peer-id 101"
@@ -18,6 +22,8 @@ services:
   smoldb-2:
     container_name: smoldb-2
     image: kshivendu/smoldb:latest
+    environment:
+      - RUST_BACKTRACE=1
     ports:
       - "9002:9000"
     # ToDo: Should be possible to wait only 5s once consensus is fully fixed

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,50 +2,23 @@ version: "3.7"
 
 services:
   smoldb-0:
-    image: ghcr.io/kshivendu/smoldb:dev
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
-    environment:
-      - QDRANT__SERVICE__GRPC_PORT=6334
-      - QDRANT__CLUSTER__ENABLED=true
-      - QDRANT__CLUSTER__RESHARDING_ENABLED=true
-      - QDRANT__CLUSTER__P2P__PORT=6335
+    container_name: smoldb-0
+    image: kshivendu/smoldb:latest
     ports:
-      - "9001:9000"
-    entrypoint: []
-    command: ./smoldb --url 'smoldb-0:9000'
+      - "9000:9000"
+    command: --url smoldb-0:9000 --p2p-url smoldb-0:5000 --peer-id 100
 
   smoldb-1:
-    image: ghcr.io/kshivendu/smoldb:dev
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
-    environment:
-      - QDRANT__SERVICE__GRPC_PORT=6334
-      - QDRANT__CLUSTER__ENABLED=true
-      - QDRANT__CLUSTER__RESHARDING_ENABLED=true
-      - QDRANT__CLUSTER__P2P__PORT=6335
-    depends_on:
-      - smoldb-0
+    container_name: smoldb-1
+    image: kshivendu/smoldb:latest
     ports:
-      - "9002:9000"
-    entrypoint: []
-    command: bash -c "sleep 5 && ./smoldb --bootstrap 'smoldb-0:5000' --url 'smoldb-1:9000'"
+      - "9001:9000"
+    command: sh -c "echo 'Waiting 5s' && sleep 5 && /smoldb --bootstrap smoldb-0:5000 --url smoldb-1:9000 --p2p-url smoldb-1:5000  --peer-id 101"
 
   smoldb-2:
-    image: ghcr.io/kshivendu/smoldb:dev
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
-    environment:
-      - QDRANT__SERVICE__GRPC_PORT=6334
-      - QDRANT__CLUSTER__ENABLED=true
-      - QDRANT__CLUSTER__RESHARDING_ENABLED=true
-      - QDRANT__CLUSTER__P2P__PORT=6335
-    depends_on:
-      - smoldb-0
+    container_name: smoldb-2
+    image: kshivendu/smoldb:latest
     ports:
-      - "9003:9000"
-    entrypoint: []
-    command: bash -c "sleep 5 && ./smoldb --bootstrap 'smoldb-0:5000' --url 'smoldb-2:9000'"
+      - "9002:9000"
+    # ToDo: Should be possible to wait only 5s once consensus is fully fixed
+    command: sh -c "echo 'Waiting 10s' && sleep 10 && /smoldb --bootstrap smoldb-0:5000 --url smoldb-2:9000 --p2p-url smoldb-2:5000 --peer-id 102"

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+if [ "$1" = "smoldb" ] || [ "${1#-}" != "$1" ]; then
+  # If the first argument is 'smoldb' or an option (starts with -), run smoldb with all args
+  exec /smoldb "$@"
+else
+  # Otherwise, run the command as-is (e.g., bash)
+  exec "$@"
+fi


### PR DESCRIPTION
This PR improves docker setup:
- Introduce `entrypoint.sh` for to make it easier to run and debug the container.
- Use `debian:12-slim` as base image since it has tools like bash/apt.
- Clean up and make `docker-compose.yaml` actually work. Made it less painful to write - no more `entrypoint` field and `command` that actually works for executing bash scripts