### PR TITLE
Rename retrieve/get points as read points

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,9 +19,9 @@ cargo run -p smolbench # upserts
 cargo run -p smolbench -- -n 100k --uri http://localhost:9001 -b 1k
 
 # terminal 1 (upsert):
-cargo run -p smolbench --  --skip-query -n 100M --delay 1000 -b 100
+cargo run -p smolbench --  --skip-read -n 100M --delay 1000 -b 100
 # terminal 2 (search):
-watch -n1 'cargo run -p smolbench --  --skip-upsert -n 100M --delay 1000 -b 100'
+watch -n1 'cargo run -p smolbench --  --skip-write -n 100M --delay 1000 -b 100'
 ```
 
 ### Criterion / flamegraph branch

--- a/benches/read_write.rs
+++ b/benches/read_write.rs
@@ -150,7 +150,7 @@ pub fn single_read(c: &mut Criterion) {
     group.bench_function("single_read", |b| {
         b.to_async(&rt).iter(|| async {
             collection
-                .get_points(Some(vec![PointId::Id(0)]), None, true)
+                .read_points(Some(vec![PointId::Id(0)]), None, true)
                 .await
                 .unwrap();
         })
@@ -206,7 +206,7 @@ fn concurrent_read(c: &mut Criterion) {
         b.to_async(&rt).iter(|| async {
             for chunk in point_ids.chunks(chunk_size) {
                 collection
-                    .get_points(Some(chunk.to_vec()), None, true)
+                    .read_points(Some(chunk.to_vec()), None, true)
                     .await
                     .unwrap();
             }

--- a/src/api/grpc/points_service.rs
+++ b/src/api/grpc/points_service.rs
@@ -47,11 +47,11 @@ impl PointsInternal for PointsInternalService {
             Some(ids.into_iter().map(PointId::Id).collect::<Vec<_>>())
         };
 
-        let points = collection.get_points(point_ids, shard_id, true).await;
+        let points = collection.read_points(point_ids, shard_id, true).await;
 
         let points = points.map_err(|e| {
             tonic::Status::internal(format!(
-                "Failed to retrieve points from collection '{collection_name}': {e}"
+                "Failed to read points from collection '{collection_name}': {e}"
             ))
         })?;
 

--- a/src/api/points.rs
+++ b/src/api/points.rs
@@ -66,7 +66,7 @@ async fn get_point(
 
         let result = dispatcher
             .toc
-            .retrieve_points(&collection_name, Some(vec![point_id]))
+            .read_points(&collection_name, Some(vec![point_id]))
             .await;
 
         match result {
@@ -96,7 +96,7 @@ async fn list_points(
 ) -> impl Responder {
     helpers::time(async {
         let collection_name = collection_name.into_inner();
-        let result = dispatcher.toc.retrieve_points(&collection_name, None).await;
+        let result = dispatcher.toc.read_points(&collection_name, None).await;
         match result {
             Ok(points) => {
                 if points.is_empty() {

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -228,7 +228,7 @@ impl Collection {
         Ok(())
     }
 
-    pub async fn get_points(
+    pub async fn read_points(
         &self,
         ids: Option<Vec<PointId>>,
         shard_id: Option<ShardId>,

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -97,7 +97,7 @@ impl Segment {
             return Ok(points);
         };
 
-        // If ids are provided, retrieve only those points
+        // If ids are provided, read only those points
         for id in ids {
             let key = id.into_string();
             if let Some(value) = self.db.get(key).map_err(|e| {

--- a/src/storage/toc.rs
+++ b/src/storage/toc.rs
@@ -175,7 +175,7 @@ impl TableOfContent {
         Ok(true)
     }
 
-    pub async fn retrieve_points(
+    pub async fn read_points(
         &self,
         collection_name: &str,
         ids: Option<Vec<PointId>>,
@@ -185,9 +185,9 @@ impl TableOfContent {
             StorageError::BadInput(format!("Collection '{collection_name}' does not exist"))
         })?;
 
-        collection.get_points(ids, None, false).await.map_err(|e| {
+        collection.read_points(ids, None, false).await.map_err(|e| {
             StorageError::ServiceError(format!(
-                "Failed to retrieve points from collection '{collection_name}': {e}"
+                "Failed to read points from collection '{collection_name}': {e}"
             ))
         })
     }

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -43,7 +43,7 @@ pub async fn get_collection(
 
     match body {
         ApiResponse::Success(body) => Ok(body),
-        ApiResponse::Error(res) => Err(SmolBenchError::RetrievePointsError(res.error)),
+        ApiResponse::Error(res) => Err(SmolBenchError::ReadPointsError(res.error)),
     }
 }
 
@@ -129,8 +129,8 @@ pub async fn upsert_points(
     Ok(results)
 }
 
-/// Retrieve points by their IDs
-pub async fn retrieve_point(
+/// Read points by their IDs
+pub async fn read_point(
     url: &Uri,
     collection_name: &str,
     ids: Vec<u64>,
@@ -150,7 +150,7 @@ pub async fn retrieve_point(
             ApiResponse::Success(body) => {
                 results.push(body);
             }
-            ApiResponse::Error(res) => Err(SmolBenchError::RetrievePointsError(res.error))?,
+            ApiResponse::Error(res) => Err(SmolBenchError::ReadPointsError(res.error))?,
         }
     }
 
@@ -159,7 +159,7 @@ pub async fn retrieve_point(
 
 /// Scroll through all points in a collection by pagination?
 /// ToDo: Implement pagination logic in smoldb APIs
-pub async fn retrieve_points(
+pub async fn read_points(
     url: &Uri,
     collection_name: &str,
     _ids: Option<Vec<PointId>>, // ToDo: Use this parameter to filter points
@@ -175,6 +175,6 @@ pub async fn retrieve_points(
 
     match body {
         ApiResponse::Success(body) => Ok(body),
-        ApiResponse::Error(res) => Err(SmolBenchError::RetrievePointsError(res.error)),
+        ApiResponse::Error(res) => Err(SmolBenchError::ReadPointsError(res.error)),
     }
 }

--- a/tools/smolbench/src/args.rs
+++ b/tools/smolbench/src/args.rs
@@ -57,11 +57,11 @@ pub struct Args {
 
     /// Use if you don't want to upsert points by default
     #[clap(long, default_value = "false")]
-    pub skip_upsert: bool,
+    pub skip_write: bool,
 
     /// Check whether to query after upsert
     #[clap(long, default_value = "false")]
-    pub skip_query: bool,
+    pub skip_read: bool,
 
     /// Number of 9 digits to show in p99* results
     /// Defaults to 3, i.e. shows only p99

--- a/tools/smolbench/src/args.rs
+++ b/tools/smolbench/src/args.rs
@@ -57,7 +57,7 @@ pub struct Args {
 
     /// Use if you don't want to upsert points by default
     #[clap(long, default_value = "false")]
-    pub skip_write: bool,
+    pub skip_upsert: bool,
 
     /// Check whether to query after upsert
     #[clap(long, default_value = "false")]

--- a/tools/smolbench/src/error.rs
+++ b/tools/smolbench/src/error.rs
@@ -8,8 +8,8 @@ pub enum SmolBenchError {
     DeleteCollectionError(String),
     #[error("Failed to upsert points: {0}")]
     UpsertPointsError(String),
-    #[error("Failed to retrieve points: {0}")]
-    RetrievePointsError(String),
+    #[error("Failed to read points: {0}")]
+    ReadPointsError(String),
     #[error("Request error: {0}")]
     RequestError(#[from] reqwest::Error),
     #[error("JSON parsing error: {0}")]

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -8,7 +8,7 @@ pub mod types;
 pub mod utils;
 
 use crate::{
-    apis::{create_collection, delete_collection, get_collection, retrieve_point, upsert_points},
+    apis::{create_collection, delete_collection, get_collection, read_point, upsert_points},
     utils::log_latencies,
 };
 use args::parse_args;
@@ -54,7 +54,7 @@ async fn main() -> Result<(), SmolBenchError> {
         }
     }
 
-    if !args.skip_upsert {
+    if !args.skip_write {
         let batch_responses = upsert_points(
             &args.uri,
             &args.collection_name,
@@ -72,20 +72,20 @@ async fn main() -> Result<(), SmolBenchError> {
         log_latencies(&batch_responses, args.p9, "server-side batched upsert").await?;
     }
 
-    if !args.skip_query {
+    if !args.skip_read {
         let num_queries = args.num_points.min(1000) as u64;
         let mut rnd = rand::rng();
         let ids = (0..num_queries)
             .map(|_| rnd.random::<u64>() % args.num_points as u64) // Assume that IDs in the range [0, num_points) have been upserted
             .collect::<Vec<_>>();
-        let responses = retrieve_point(&args.uri, &args.collection_name, ids).await?;
+        let responses = read_point(&args.uri, &args.collection_name, ids).await?;
         println!(
-            "Retrieved {} points from collection '{}':",
+            "Read {} points from collection '{}':",
             responses.len(),
             args.collection_name,
         );
 
-        log_latencies(&responses, args.p9, "server-side retrieve").await?;
+        log_latencies(&responses, args.p9, "server-side read").await?;
     }
 
     Ok(())

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), SmolBenchError> {
         }
     }
 
-    if !args.skip_write {
+    if !args.skip_upsert {
         let batch_responses = upsert_points(
             &args.uri,
             &args.collection_name,

--- a/tools/smolbench/src/tests/mod.rs
+++ b/tools/smolbench/src/tests/mod.rs
@@ -28,7 +28,7 @@ async fn test_smoldb_consecutive_writes() -> Result<(), crate::error::SmolBenchE
 
     assert_eq!(upsert_response.len(), expected_batch_count);
 
-    let get_points = crate::apis::retrieve_points(&uri, &collection_name, None).await?;
+    let get_points = crate::apis::read_points(&uri, &collection_name, None).await?;
     assert_eq!(get_points.result.points.len(), num_points);
 
     Ok(())


### PR DESCRIPTION
Make APIs easier to remember and call. Improve dev-ex

- Both Get/Retrieve points are now consistently called as Read points
- Upsert is still called upsert but not write because there might be multiple ways to read/query the points (filter/vector search, scroll, etc) but there's only one mode of writing in smoldb - upsert.