### PR TITLE
wait for collection created/deleted in smolbench

### DIFF
--- a/src/api/dispatcher.rs
+++ b/src/api/dispatcher.rs
@@ -47,6 +47,9 @@ impl Dispatcher {
             .await?;
         self.toc.perform_collection_op(operation).await?;
 
+        // ToDo: Should return the response of the consensus operation as result: true or acknowledged: true (if consensus)
+        // ToDo: Add `wait` param to wait for the consensus operation to be applied across the cluster
+
         Ok(())
     }
 

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -8,6 +8,7 @@ use tokio::time::sleep;
 
 const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Strongly recommend to use `wait=true`
 pub async fn create_collection(
     url: &Uri,
     collection_name: &str,
@@ -91,6 +92,7 @@ pub async fn exists_collection(url: &Uri, collection_name: &str) -> Result<bool,
     }
 }
 
+/// Strongly recommend to use `wait=true`
 pub async fn delete_collection(
     url: &Uri,
     collection_name: &str,

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -6,9 +6,12 @@ use serde_json::{json, Value};
 use std::time::Duration;
 use tokio::time::sleep;
 
+const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
 pub async fn create_collection(
     url: &Uri,
     collection_name: &str,
+    wait: bool,
 ) -> Result<ApiSuccessResponse<bool>, SmolBenchError> {
     let client = reqwest::Client::new();
 
@@ -22,16 +25,43 @@ pub async fn create_collection(
 
     let body: ApiResponse<bool> = res.json().await?;
 
-    match body {
+    let now = std::time::Instant::now();
+
+    let success_res = match body {
         ApiResponse::Success(body) => Ok(body),
         ApiResponse::Error(res) => Err(SmolBenchError::CreateCollectionError(res.error)),
+    }?;
+
+    if wait {
+        while now.elapsed() < WAIT_TIMEOUT {
+            let exists = exists_collection(url, collection_name).await?;
+
+            if exists {
+                return Ok(success_res);
+            }
+
+            println!(
+                "Waiting for collection '{}' to be created...",
+                collection_name
+            );
+
+            if now.elapsed() >= WAIT_TIMEOUT {
+                return Err(SmolBenchError::CreateCollectionError(
+                    "Timed out waiting for collection creation".to_string(),
+                ));
+            }
+
+            sleep(Duration::from_millis(100)).await;
+        }
     }
+
+    Ok(success_res)
 }
 
-pub async fn get_collection(
+async fn get_collection(
     url: &Uri,
     collection_name: &str,
-) -> Result<ApiSuccessResponse<Value>, SmolBenchError> {
+) -> Result<ApiResponse<Value>, SmolBenchError> {
     let client = reqwest::Client::new();
 
     let res = client
@@ -41,13 +71,31 @@ pub async fn get_collection(
 
     let body: ApiResponse<Value> = res.json().await?;
 
-    match body {
-        ApiResponse::Success(body) => Ok(body),
-        ApiResponse::Error(res) => Err(SmolBenchError::ReadPointsError(res.error)),
+    Ok(body)
+}
+
+pub async fn exists_collection(url: &Uri, collection_name: &str) -> Result<bool, SmolBenchError> {
+    // It's important to differentiate between collection not existing vs request/parsing
+    match get_collection(url, collection_name).await {
+        Ok(ApiResponse::Success(_collection)) => Ok(true),
+        Ok(ApiResponse::Error(error_res)) => {
+            if error_res.error
+                == format!("Service error: Collection: {collection_name} doesn't exist")
+            {
+                Ok(false)
+            } else {
+                Err(SmolBenchError::CollectionExistsError(error_res.error))
+            }
+        }
+        Err(e) => Err(e),
     }
 }
 
-pub async fn delete_collection(url: &Uri, collection_name: &str) -> Result<(), SmolBenchError> {
+pub async fn delete_collection(
+    url: &Uri,
+    collection_name: &str,
+    wait: bool,
+) -> Result<(), SmolBenchError> {
     let client = reqwest::Client::new();
 
     let res = client
@@ -55,15 +103,38 @@ pub async fn delete_collection(url: &Uri, collection_name: &str) -> Result<(), S
         .send()
         .await?;
 
-    if res.status().is_success() {
-        Ok(())
-    } else {
-        let body: ApiResponse<Value> = res.json().await?;
-        match body {
-            ApiResponse::Success(_) => Ok(()),
-            ApiResponse::Error(res) => Err(SmolBenchError::DeleteCollectionError(res.error)),
+    let body: ApiResponse<Value> = res.json().await?;
+    let success_res = match body {
+        ApiResponse::Success(_) => Ok(()),
+        ApiResponse::Error(res) => Err(SmolBenchError::DeleteCollectionError(res.error)),
+    }?;
+
+    let now = std::time::Instant::now();
+
+    if wait {
+        while now.elapsed() < WAIT_TIMEOUT {
+            let deleted = !exists_collection(url, collection_name).await?;
+
+            if deleted {
+                return Ok(success_res);
+            }
+
+            println!(
+                "Waiting for collection '{}' to be deleted...",
+                collection_name
+            );
+
+            if now.elapsed() >= WAIT_TIMEOUT {
+                return Err(SmolBenchError::CreateCollectionError(
+                    "Timed out waiting for collection deletion".to_string(),
+                ));
+            }
+
+            sleep(Duration::from_millis(100)).await;
         }
     }
+
+    Ok(success_res)
 }
 
 pub async fn upsert_points(

--- a/tools/smolbench/src/error.rs
+++ b/tools/smolbench/src/error.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum SmolBenchError {
     #[error("Failed to create collection: {0}")]
     CreateCollectionError(String),
+    #[error("Failed to check if collection exists: {0}")]
+    CollectionExistsError(String),
     #[error("Failed to delete collection: {0}")]
     DeleteCollectionError(String),
     #[error("Failed to upsert points: {0}")]

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -8,7 +8,7 @@ pub mod types;
 pub mod utils;
 
 use crate::{
-    apis::{create_collection, delete_collection, get_collection, read_point, upsert_points},
+    apis::{create_collection, delete_collection, exists_collection, read_point, upsert_points},
     utils::log_latencies,
 };
 use args::parse_args;
@@ -21,9 +21,7 @@ async fn main() -> Result<(), SmolBenchError> {
     // println!("Parsed arguments: {:?}", &args);
 
     if !args.skip_create {
-        let exists = get_collection(&args.uri, &args.collection_name)
-            .await
-            .is_ok();
+        let exists = exists_collection(&args.uri, &args.collection_name).await?;
 
         if exists {
             if args.skip_if_exists {
@@ -36,8 +34,8 @@ async fn main() -> Result<(), SmolBenchError> {
                     "Collection '{}' already exists, deleting it and creating a new one",
                     args.collection_name
                 );
-                delete_collection(&args.uri, &args.collection_name).await?;
-                match create_collection(&args.uri, &args.collection_name).await {
+                delete_collection(&args.uri, &args.collection_name, true).await?;
+                match create_collection(&args.uri, &args.collection_name, true).await {
                     Ok(_) => println!("Collection created successfully."),
                     Err(e) => return Err(SmolBenchError::CreateCollectionError(e.to_string()))?,
                 }
@@ -47,7 +45,7 @@ async fn main() -> Result<(), SmolBenchError> {
                 "Collection '{}' does not exist, creating it",
                 args.collection_name
             );
-            match create_collection(&args.uri, &args.collection_name).await {
+            match create_collection(&args.uri, &args.collection_name, true).await {
                 Ok(_) => println!("Collection created successfully."),
                 Err(e) => return Err(SmolBenchError::CreateCollectionError(e.to_string()))?,
             }

--- a/tools/smolbench/src/tests/mod.rs
+++ b/tools/smolbench/src/tests/mod.rs
@@ -16,7 +16,8 @@ async fn test_smoldb_consecutive_writes() -> Result<(), crate::error::SmolBenchE
     let batch_size: usize = 100;
     let delay = None;
 
-    if let Ok(create_response) = crate::apis::create_collection(&uri, &collection_name).await {
+    if let Ok(create_response) = crate::apis::create_collection(&uri, &collection_name, true).await
+    {
         println!("Result: {}", &create_response.result);
         assert!(create_response.result);
     };


### PR DESCRIPTION
Make `smolbench` aware of consensus's async nature. We now need to wait for collection to be created/deleted.