### PR TITLE
Fix failing smolbench tests

### DIFF
--- a/tests/smolbench.sh
+++ b/tests/smolbench.sh
@@ -2,4 +2,4 @@
 set -eoux pipefail
 
 cargo build
-cargo test -p smolbench
+cargo test -p smolbench -- --nocapture

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -8,12 +8,63 @@ use tokio::time::sleep;
 
 const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
+pub async fn wait_consensus_start(url: &Uri) -> Result<(), SmolBenchError> {
+    let now = std::time::Instant::now();
+
+    while now.elapsed() < WAIT_TIMEOUT {
+        let cluster_info = get_cluster_info(url).await?;
+
+        match cluster_info {
+            ApiResponse::Success(info) => {
+                let leader = info
+                    .result
+                    .get("raft_info")
+                    .and_then(|r| r.get("leader"))
+                    .and_then(|r| r.as_u64())
+                    .unwrap();
+
+                if leader != 0 {
+                    println!("Consensus started with leader: {}", leader);
+                    return Ok(());
+                } else {
+                    println!("No leader found in cluster info, waiting for consensus to start...");
+                }
+            }
+            ApiResponse::Error(err) => {
+                return Err(SmolBenchError::ConsensusError(format!(
+                    "Cluster not started: {}",
+                    err.error
+                )));
+            }
+        }
+
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    Err(SmolBenchError::ConsensusError(
+        "Timed out waiting for consensus to start".to_string(),
+    ))
+}
+
+async fn get_cluster_info(url: &Uri) -> Result<ApiResponse<Value>, SmolBenchError> {
+    let client = reqwest::Client::new();
+
+    let res = client.get(format!("{url}/cluster")).send().await?;
+
+    let body: ApiResponse<Value> = res.json().await?;
+
+    Ok(body)
+}
+
 /// Strongly recommend to use `wait=true`
 pub async fn create_collection(
     url: &Uri,
     collection_name: &str,
     wait: bool,
 ) -> Result<ApiSuccessResponse<bool>, SmolBenchError> {
+    // First ensure that consensus is started
+    crate::apis::wait_consensus_start(&url).await?;
+
     let client = reqwest::Client::new();
 
     let res = client
@@ -94,6 +145,9 @@ pub async fn delete_collection(
     collection_name: &str,
     wait: bool,
 ) -> Result<(), SmolBenchError> {
+    // First ensure that consensus is started
+    crate::apis::wait_consensus_start(&url).await?;
+
     let client = reqwest::Client::new();
 
     let res = client

--- a/tools/smolbench/src/error.rs
+++ b/tools/smolbench/src/error.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum SmolBenchError {
+    #[error("Consensus error: {0}")]
+    ConsensusError(String),
     #[error("Failed to create collection: {0}")]
     CreateCollectionError(String),
     #[error("Failed to check if collection exists: {0}")]

--- a/tools/smolbench/src/tests/mod.rs
+++ b/tools/smolbench/src/tests/mod.rs
@@ -1,6 +1,6 @@
 mod utils;
 
-use self::utils::start_peer;
+use self::utils::start_smoldb;
 use http::Uri;
 use std::str::FromStr;
 use temp_dir::TempDir;
@@ -8,7 +8,7 @@ use temp_dir::TempDir;
 #[tokio::test]
 async fn test_smoldb_consecutive_writes() -> Result<(), crate::error::SmolBenchError> {
     let peer_dir = TempDir::new().expect("Failed to create temp dir");
-    let _child = start_peer(peer_dir.path(), "test_peer.log", 101, 9001, 5001, None).await;
+    let _node = start_smoldb(peer_dir.path(), "test_peer.log", 101, 9001, 5001, None).await;
 
     let uri = Uri::from_str("http://localhost:9001").unwrap();
     let collection_name = "benchmark".to_string();
@@ -16,11 +16,10 @@ async fn test_smoldb_consecutive_writes() -> Result<(), crate::error::SmolBenchE
     let batch_size: usize = 100;
     let delay = None;
 
-    if let Ok(create_response) = crate::apis::create_collection(&uri, &collection_name, true).await
-    {
-        println!("Result: {}", &create_response.result);
-        assert!(create_response.result);
-    };
+    let create_response = crate::apis::create_collection(&uri, &collection_name, true).await?;
+
+    println!("Result: {}", &create_response.result);
+    assert!(create_response.result);
 
     let expected_batch_count = num_points.div_ceil(batch_size);
 

--- a/tools/smolbench/src/tests/utils.rs
+++ b/tools/smolbench/src/tests/utils.rs
@@ -14,23 +14,42 @@ fn get_smoldb_exec() -> PathBuf {
 async fn wait_peer_start(uri: &str) {
     let client = reqwest::Client::new();
     let start = std::time::Instant::now();
-    while let Err(_) = client.get(uri).send().await {
+    while let Err(e) = client.get(uri).send().await {
         if start.elapsed() > MAX_PEER_WAIT {
-            panic!("Smoldb peer did not start within the expected time");
+            panic!("Smoldb peer did not start within the expected time: {e}");
         }
     }
 }
 
-pub async fn start_peer(
+pub struct SmolDbNode {
+    child: std::process::Child,
+}
+
+impl SmolDbNode {
+    pub fn new(child: std::process::Child) -> Self {
+        SmolDbNode { child }
+    }
+}
+
+impl Drop for SmolDbNode {
+    fn drop(&mut self) {
+        if let Err(e) = self.child.kill() {
+            eprintln!("Failed to kill Smoldb process: {e}");
+        }
+    }
+}
+
+pub async fn start_smoldb(
     peer_dir: &Path,
     log_file: &str,
     peer_id: u64,
     port: u32,
     p2p_port: u32,
     bootstrap: Option<String>,
-) -> std::process::Child {
+) -> SmolDbNode {
     let smoldb_path = get_smoldb_exec();
-    let log_path = peer_dir.join(log_file); // ToDo: Add logging
+    let cwd = std::env::current_dir().expect("Failed to get current directory");
+    let log_path = cwd.join(log_file); // ToDo: Add logging
 
     if !smoldb_path.exists() {
         panic!("Smoldb executable not found at {:?}", smoldb_path);
@@ -76,5 +95,5 @@ pub async fn start_peer(
 
     println!("Started Smoldb peer at {http_url} in {peer_dir:?}");
 
-    child
+    SmolDbNode::new(child)
 }


### PR DESCRIPTION
When running integration tests for smolbench, we trigger everything fast. And this means we don't wait for consensus to start before calling create/delete collection APIs. Therefore we end up returning `true` even when consensus hasn't accepted the operation (hasn't even started) and upserts fail

Also introduce `SmolDbNode` to kill smoldb process when the variable is dropped.