### PR TITLE
Limit the number of points that can be fetched at once

### DIFF
--- a/src/api/points.rs
+++ b/src/api/points.rs
@@ -89,14 +89,24 @@ pub struct ListPointsResponse {
     pub points: Vec<Point>,
 }
 
-#[actix_web::get("/collections/{collection_name}/points")]
+#[derive(Deserialize)]
+pub struct ListPointsRequest {
+    pub ids: Vec<PointId>,
+}
+
+#[actix_web::post("/collections/{collection_name}/points")]
 async fn list_points(
     collection_name: web::Path<String>,
+    operation: Json<ListPointsRequest>,
     dispatcher: web::Data<Dispatcher>,
 ) -> impl Responder {
     helpers::time(async {
         let collection_name = collection_name.into_inner();
-        let result = dispatcher.toc.read_points(&collection_name, None).await;
+        let ids = operation.into_inner().ids;
+        let result = dispatcher
+            .toc
+            .read_points(&collection_name, Some(ids))
+            .await;
         match result {
             Ok(points) => {
                 if points.is_empty() {


### PR DESCRIPTION
Also removes the GET points API which allowed fetching all points. I'm fine with not doing pagination just yet.  Resolves https://github.com/KShivendu/smoldb/issues/52

Before:
```sh
GET /collections/benchmark/points

# If you add remote shards (uses gRPC) and store 1M points, it throws error:
# decoded message length too large the limit is: 4194304 bytes
# which can be resolved by setting max_encoding_message_size(), max_decoding_message_size() on client and server.
# But I think it's better to drop the API for now. Might introduce some filtering with pagination later on.
```

After:
```http
POST /collections/benchmark/points
{
  "ids": [0, 1]
}
```