### PR TITLE
Introduce shard states and mark replica as Dead on failed update

### DIFF
--- a/src/api/collection.rs
+++ b/src/api/collection.rs
@@ -2,6 +2,7 @@ use crate::api::dispatcher::Dispatcher;
 use crate::api::helpers;
 use crate::error::CollectionError;
 use crate::storage::collection::{Collection, CollectionInfo};
+use crate::storage::replicas::ShardState;
 use crate::storage::toc::CollectionOperation;
 use crate::types::{PeerId, ShardId};
 use actix_web::{
@@ -74,14 +75,14 @@ async fn delete_collection(
 pub struct CollectionClusterLocalShard {
     pub shard_id: ShardId,
     pub point_count: usize,
-    pub state: String,
+    pub state: ShardState,
 }
 
 #[derive(Serialize)]
 pub struct CollectionClusterRemoteShard {
     pub peer_id: PeerId,
     pub shard_id: ShardId,
-    pub state: String,
+    pub state: ShardState,
 }
 
 #[derive(Serialize)]
@@ -103,7 +104,7 @@ impl CollectionClusterInfo {
                 // FixMe: Not all replicas will have a local shard
                 shard_id: *shard_id,
                 point_count: replica_set.local.count_points(),
-                state: "Active".to_string(), // ToDo: Placeholder for actual state
+                state: replica_set.local.shard_state.clone(),
             })
             .collect::<Vec<_>>();
 
@@ -113,7 +114,7 @@ impl CollectionClusterInfo {
                 remote_shards.push(CollectionClusterRemoteShard {
                     peer_id: remote_shard.peer_id,
                     shard_id: remote_shard.id,
-                    state: "Active".to_string(), // ToDo: Placeholder for actual state
+                    state: remote_shard.state.clone(),
                 });
             }
         }

--- a/src/api/dispatcher.rs
+++ b/src/api/dispatcher.rs
@@ -84,7 +84,7 @@ impl Dispatcher {
                 uri: uri.to_string(),
             },
             callback: Box::new(move || {
-                println!("Callback executed operation with ID {operation_id}");
+                log::info!("Callback executed operation with ID {operation_id}");
             }),
         });
 

--- a/src/api/grpc/points_service.rs
+++ b/src/api/grpc/points_service.rs
@@ -8,6 +8,7 @@ use crate::{
         toc::TableOfContent,
     },
 };
+use log::debug;
 use std::sync::Arc;
 use tonic::{async_trait, Response};
 
@@ -79,7 +80,7 @@ impl PointsInternal for PointsInternalService {
             points,
             shard_id: _, // ToDo: We should specify shard_id when upserting?
         } = _request.into_inner();
-        println!("Received internal request to upsert points from collection: {collection_name}");
+        debug!("Received internal request to upsert points from collection: {collection_name}");
 
         let collections = self.toc.collections.read().await;
         let collection = collections.get(&collection_name).ok_or_else(|| {

--- a/src/channel_service.rs
+++ b/src/channel_service.rs
@@ -6,8 +6,8 @@ use tonic::transport::{Channel, Error as TonicError};
 
 #[derive(Default)]
 /// This service is used to manage [`Channel`] connection pools between peers
-/// It maintains connection pools and handles re-connection
 pub struct ChannelService {
+    /// It maintains connection pools and handles re-connection
     pub peer_id: PeerId,
     /// Directly shared with `ConsensusState` instead of having a .add_peer() function
     pub id_to_address: Arc<RwLock<HashMap<PeerId, Uri>>>,
@@ -20,6 +20,14 @@ pub struct ChannelService {
 }
 
 impl ChannelService {
+    pub fn empty(peer_id: PeerId) -> Self {
+        Self {
+            peer_id,
+            id_to_address: Arc::new(RwLock::new(HashMap::new())),
+            uri_to_channel: RwLock::new(HashMap::new()),
+        }
+    }
+
     pub fn new(peer_id: PeerId, id_to_address: Arc<RwLock<HashMap<PeerId, Uri>>>) -> Self {
         Self {
             peer_id,

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -308,7 +308,7 @@ impl Consensus {
                                 operation,
                                 callback,
                             } => {
-                                println!(
+                                log::info!(
                                     "Received proposal with ID: {id} and operation: {operation:?}"
                                 );
                                 callbacks.insert(id, callback);

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -10,7 +10,7 @@ use crate::{
     types::{PeerId, ShardId},
 };
 use futures::FutureExt;
-use log::error;
+use log::{error, info};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{btree_map::Entry, BTreeMap, HashMap},
@@ -163,7 +163,7 @@ impl Collection {
         points: Vec<Point>,
         local_only: bool,
     ) -> CollectionResult<()> {
-        let shard_holder = &self.replica_holder.read().await;
+        let replica_holder_guard = self.replica_holder.read().await;
 
         let point_ids: Vec<_> = points.iter().map(|point| point.id.clone()).collect();
 
@@ -172,9 +172,11 @@ impl Collection {
             .map(|point| (point.id.clone(), point))
             .collect();
 
+        let mut replicas_to_mark_dead = vec![];
+
         // ToDo: Run this operation concurrently for each shard
-        for (shard_id, shard_point_ids) in shard_holder.select_shards(&point_ids)? {
-            let replica_set = shard_holder
+        for (shard_id, shard_point_ids) in replica_holder_guard.select_shards(&point_ids)? {
+            let replica_set = replica_holder_guard
                 .shards
                 .get(&shard_id)
                 .ok_or_else(|| StorageError::BadInput(format!("Shard {shard_id} not found")))?;
@@ -205,13 +207,8 @@ impl Collection {
 
             for (remote_peer_id, result) in remote_results {
                 if let Err(e) = result {
-                    error!("Failed to upsert points in remote shard {shard_id} for peer {remote_peer_id}: {e}");
-                    // Mark the replica with missed update as Dead
-                    self.replica_holder
-                        .write()
-                        .await
-                        .set_replica_state(shard_id, *remote_peer_id, None, ShardState::Dead)
-                        .await?;
+                    error!("Failed to upsert points in remote shard {shard_id} for peer {remote_peer_id}: {e}. Will mark it as dead.");
+                    replicas_to_mark_dead.push((shard_id, *remote_peer_id));
                 }
             }
 
@@ -230,6 +227,21 @@ impl Collection {
                     "Failed to upsert points in shard {shard_id}: only {total_success} out of {num_replicas} replicas succeeded"
                 )));
             }
+        }
+
+        // Release the read lock before taking write lock
+        drop(replica_holder_guard);
+
+        // Mark the replicas that missed the update as Dead
+        for (shard_id, peer_id) in replicas_to_mark_dead {
+            self.replica_holder
+                .write()
+                .await
+                .set_replica_state(shard_id, peer_id, None, ShardState::Dead)
+                .await?;
+            info!(
+                "Marked remote shard {shard_id} for peer {peer_id} as Dead due to failed upsert."
+            );
         }
 
         Ok(())

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -2,12 +2,15 @@ use crate::{
     channel_service::ChannelService,
     error::{CollectionError, CollectionResult, StorageError},
     storage::{
-        replicas::{local_shard::LocalShard, ReplicaHolder, ReplicaSet, ShardOperationTrait},
+        replicas::{
+            local_shard::LocalShard, ReplicaHolder, ReplicaSet, ShardOperationTrait, ShardState,
+        },
         segment::{Point, PointId},
     },
     types::{PeerId, ShardId},
 };
 use futures::FutureExt;
+use log::error;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{btree_map::Entry, BTreeMap, HashMap},
@@ -191,13 +194,25 @@ impl Collection {
                 )
                 .await;
 
-            let total_success = results.iter().filter(|r| r.is_ok()).count();
+            let total_success = results.iter().filter(|(_, r)| r.is_ok()).count();
 
-            let (local_result, _remote_results) = results.split_first().unwrap();
+            let ((_peer_id, local_result), remote_results) = results.split_first().unwrap();
             if let Err(e) = local_result {
                 return Err(CollectionError::ServiceError(format!(
                     "Failed to upsert points in local shard {shard_id}: {e}"
                 )));
+            }
+
+            for (remote_peer_id, result) in remote_results {
+                if let Err(e) = result {
+                    error!("Failed to upsert points in remote shard {shard_id} for peer {remote_peer_id}: {e}");
+                    // Mark the replica with missed update as Dead
+                    self.replica_holder
+                        .write()
+                        .await
+                        .set_replica_state(shard_id, *remote_peer_id, None, ShardState::Dead)
+                        .await?;
+                }
             }
 
             // ToDo: Both should have collection level config
@@ -248,6 +263,7 @@ impl Collection {
                     )
                     .await
                     .into_iter()
+                    .map(|(_peer_id, r)| r)
                     .collect::<Result<Vec<_>, _>>()?;
 
                 for point in replica_results.into_iter().flatten() {

--- a/src/storage/replicas/local_shard.rs
+++ b/src/storage/replicas/local_shard.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{CollectionError, CollectionResult, StorageError},
     storage::{
-        replicas::ShardOperationTrait,
+        replicas::{ShardOperationTrait, ShardState},
         segment::{Point, PointId, Segment},
     },
     types::{SegmentId, ShardId},
@@ -15,6 +15,7 @@ pub struct LocalShard {
     pub id: ShardId,
     pub path: PathBuf,
     pub segments: HashMap<SegmentId, Segment>,
+    pub shard_state: ShardState,
     // ToDo: Wal
 }
 
@@ -58,6 +59,7 @@ impl LocalShard {
             id,
             path: path.to_owned(),
             segments: HashMap::from_iter([(0, segment0)]),
+            shard_state: ShardState::Active,
         }
     }
 
@@ -96,6 +98,7 @@ impl LocalShard {
             id,
             path: path.to_owned(),
             segments,
+            shard_state: ShardState::Active, // ToDo: Load from disk?
         })
     }
 

--- a/src/storage/replicas/mod.rs
+++ b/src/storage/replicas/mod.rs
@@ -9,6 +9,7 @@ use crate::storage::{collection::CollectionName, segment::PointId};
 use crate::types::{PeerId, ShardId};
 use futures::future::BoxFuture;
 use log::warn;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tonic::async_trait;
@@ -22,6 +23,12 @@ pub struct UpdateResult {
 pub trait ShardOperationTrait {
     async fn get_points(&self, ids: Option<Vec<PointId>>) -> CollectionResult<Vec<Point>>;
     async fn upsert_points(&self, points: Vec<Point>) -> CollectionResult<()>;
+}
+
+#[derive(Serialize, PartialEq, Debug, Clone)]
+pub enum ShardState {
+    Active,
+    Dead,
 }
 
 pub struct ReplicaSet {
@@ -50,9 +57,13 @@ impl ReplicaSet {
         }
     }
 
+    pub fn get_peer_id(&self) -> PeerId {
+        self.channel_service.peer_id
+    }
+
     /// Add a remote shard to the replica set
     pub async fn add_remote(&mut self, peer_id: PeerId) {
-        if peer_id == self.channel_service.peer_id {
+        if peer_id == self.get_peer_id() {
             warn!("Cannot add local shard as remote replica: {peer_id}");
             return;
         }
@@ -84,12 +95,12 @@ impl ReplicaSet {
         &self,
         operation: F,
         local_only: bool,
-    ) -> Vec<CollectionResult<Res>>
+    ) -> Vec<(PeerId, CollectionResult<Res>)>
     where
         F: Fn(&(dyn ShardOperationTrait + Send + Sync)) -> BoxFuture<'_, CollectionResult<Res>>,
     {
         let local_result = operation(&self.local).await;
-        let mut final_results = vec![local_result];
+        let mut final_results = vec![(self.get_peer_id(), local_result)];
 
         if local_only {
             return final_results;
@@ -98,14 +109,14 @@ impl ReplicaSet {
         for remote in self.remotes.values() {
             let operation_result = operation(remote).await;
             match operation_result {
-                Ok(res) => final_results.push(Ok(res)),
+                Ok(res) => final_results.push((remote.peer_id, Ok(res))),
                 Err(e) => {
                     // Ignore errors from remote shards, but log them
                     println!(
                         "Error executing operation on remote shard {}/{}: {}",
                         remote.peer_id, remote.id, e
                     );
-                    final_results.push(Err(e));
+                    final_results.push((remote.peer_id, Err(e)));
                 }
             }
         }
@@ -151,6 +162,43 @@ impl ReplicaHolder {
         Ok(replica_set)
     }
 
+    // Proposes an operation to set replica state provided the it matches the existing state.
+    pub async fn set_replica_state(
+        &mut self,
+        shard_id: ShardId,
+        peer_id: PeerId,
+        from_state: Option<ShardState>,
+        state: ShardState,
+    ) -> Result<(), StorageError> {
+        let replica_set = self
+            .shards
+            .get_mut(&shard_id)
+            .ok_or_else(|| StorageError::BadInput(format!("Shard {shard_id} not found")))?;
+
+        let remote = replica_set.remotes.get_mut(&peer_id).ok_or_else(|| {
+            StorageError::BadInput(format!(
+                "Remote peer {peer_id} not found in shard {shard_id}"
+            ))
+        })?;
+
+        if let Some(expected_state) = from_state {
+            if remote.state == expected_state {
+                // Modify only if the current state matches the expected state
+                remote.state = state;
+            } else {
+                return Err(StorageError::BadInput(format!(
+                    "Remote peer {peer_id} in shard {shard_id} is in state {:?}, expected {:?}",
+                    remote.state, expected_state
+                )));
+            }
+        } else {
+            // If no expected state is provided, just set the state
+            remote.state = state;
+        }
+
+        Ok(())
+    }
+
     pub fn select_shards(
         &self,
         point_ids: &[PointId],
@@ -179,10 +227,11 @@ mod tests {
     async fn test_shard_routing() {
         let tmp_dir = tempfile::tempdir().unwrap();
 
+        let peer_id: PeerId = 100;
         let s0 = LocalShard::init(tmp_dir.path().join("0"), 0);
         let s1 = LocalShard::init(tmp_dir.path().join("1"), 1);
 
-        let cs = Arc::new(ChannelService::default());
+        let cs = Arc::new(ChannelService::empty(peer_id));
 
         let shard_holder = ReplicaHolder::new(HashMap::from_iter([
             (0, ReplicaSet::new(s0, "c1".to_string(), 0, cs.clone())),

--- a/src/storage/replicas/mod.rs
+++ b/src/storage/replicas/mod.rs
@@ -8,7 +8,7 @@ use crate::storage::segment::Point;
 use crate::storage::{collection::CollectionName, segment::PointId};
 use crate::types::{PeerId, ShardId};
 use futures::future::BoxFuture;
-use log::warn;
+use log::{error, warn};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -112,7 +112,7 @@ impl ReplicaSet {
                 Ok(res) => final_results.push((remote.peer_id, Ok(res))),
                 Err(e) => {
                     // Ignore errors from remote shards, but log them
-                    println!(
+                    error!(
                         "Error executing operation on remote shard {}/{}: {}",
                         remote.peer_id, remote.id, e
                     );

--- a/src/storage/replicas/remote_shard.rs
+++ b/src/storage/replicas/remote_shard.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{CollectionError, CollectionResult},
     storage::{
         collection::CollectionName,
-        replicas::ShardOperationTrait,
+        replicas::{ShardOperationTrait, ShardState},
         segment::{Point, PointId},
     },
     types::{PeerId, ShardId},
@@ -20,6 +20,7 @@ pub struct RemoteShard {
     pub collection: CollectionName,
     pub peer_id: PeerId,
     pub channel_service: Arc<ChannelService>,
+    pub state: ShardState,
 }
 
 impl RemoteShard {
@@ -35,6 +36,7 @@ impl RemoteShard {
             collection,
             peer_id,
             channel_service,
+            state: ShardState::Active,
         }
     }
 


### PR DESCRIPTION
Required to build any kind of replica sync/transfer mechanism.