### PR TITLE
fix smoldb always adding leader as remote shard peer

### DIFF
--- a/src/api/dispatcher.rs
+++ b/src/api/dispatcher.rs
@@ -89,8 +89,9 @@ impl Dispatcher {
         });
 
         // Update local consensus state
+        // ToDo: Await Consensus::AddPeer consensus operation to be applied via ready_processor::handle_normal() to add remote replicas and other stuff instead of doing it forcefully here.
         let (this_peer_id, updated_peers) =
-            add_peer_to_toc_and_consensus_state(&consensus.state, &self.toc, peer_id, uri)
+            add_peer_to_toc_and_consensus_state(&consensus.state, &self.toc, peer_id, uri, true)
                 .await
                 .map_err(|e| {
                     ConsensusError::ServiceError(format!(

--- a/src/consensus/debuggables.rs
+++ b/src/consensus/debuggables.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use prost_for_raft::Message;
 use raft::prelude::{ConfChange, ConfChangeV2, Entry, EntryType, Snapshot};
 
@@ -52,7 +53,7 @@ impl DebuggableEntry {
     pub fn log(&self, prefix: &str) {
         let debuggable_entry =
             serde_json::to_string(self).expect("Failed to serialize entry to JSON");
-        println!("{prefix}: {debuggable_entry}");
+        debug!("{prefix}: {debuggable_entry}");
     }
 }
 

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -182,6 +182,7 @@ impl Consensus {
                 &self.toc,
                 peer.id,
                 peer.uri.parse::<Uri>()?,
+                true,
             )
             .await?;
         }

--- a/src/consensus/ready_processor.rs
+++ b/src/consensus/ready_processor.rs
@@ -160,9 +160,16 @@ impl Consensus {
             ConsensusOperation::AddPeer { peer_id, uri } => {
                 let uri = uri.parse::<Uri>().expect("Failed to parse URI");
                 extra_runtime.spawn(async move {
-                    add_peer_to_toc_and_consensus_state(&consensus_state, &toc, peer_id, uri)
-                        .await
-                        .expect("Failed to add peer to consensus state and TOC");
+                    // We don't add remote replicas here because it was already done by ConfChange::AddNode
+                    add_peer_to_toc_and_consensus_state(
+                        &consensus_state,
+                        &toc,
+                        peer_id,
+                        uri,
+                        false,
+                    )
+                    .await
+                    .expect("Failed to add peer to consensus state and TOC");
                 })
             }
             ConsensusOperation::CollectionOp(op) => extra_runtime.spawn(async move {

--- a/src/consensus/utils.rs
+++ b/src/consensus/utils.rs
@@ -9,14 +9,20 @@ pub async fn add_peer_to_toc_and_consensus_state(
     toc: &Arc<TableOfContent>,
     peer_id: PeerId,
     uri: Uri,
+    add_remote_replicas: bool,
 ) -> Result<(PeerId, Vec<(PeerId, String)>), ConsensusError> {
-    let (peer_id, all_peers) = consensus_state.add_peer(peer_id, uri).await.map_err(|e| {
-        ConsensusError::ServiceError(format!("Failed to add peer to local consensus state: {e}"))
-    })?;
+    let (_leader_peer_id, all_peers) =
+        consensus_state.add_peer(peer_id, uri).await.map_err(|e| {
+            ConsensusError::ServiceError(format!(
+                "Failed to add peer to local consensus state: {e}"
+            ))
+        })?;
 
-    let collections = toc.collections.read().await;
-    for collection in collections.values() {
-        collection.add_remote_replicas(peer_id).await;
+    if add_remote_replicas {
+        let collections = toc.collections.read().await;
+        for collection in collections.values() {
+            collection.add_remote_replicas(peer_id).await;
+        }
     }
 
     Ok((peer_id, all_peers))

--- a/src/consensus/utils.rs
+++ b/src/consensus/utils.rs
@@ -21,7 +21,12 @@ pub async fn add_peer_to_toc_and_consensus_state(
     if add_remote_replicas {
         let collections = toc.collections.read().await;
         for collection in collections.values() {
-            collection.add_remote_replicas(peer_id).await;
+            collection.add_remote_replicas(peer_id).await.map_err(|e| {
+                ConsensusError::ServiceError(format!(
+                    "Failed to add remote replicas for peer {peer_id} in collection {}: {e}",
+                    collection.id
+                ))
+            })?;
         }
     }
 

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -73,11 +73,13 @@ impl Collection {
     }
 
     /// ToDo: Should only add a remote replica, but only for one shard at a time
-    pub async fn add_remote_replicas(&self, peer_id: PeerId) {
+    pub async fn add_remote_replicas(&self, peer_id: PeerId) -> Result<(), StorageError> {
         let mut replica_holder = self.replica_holder.write().await;
         for (_shard_id, replica_set) in replica_holder.shards.iter_mut() {
-            replica_set.add_remote(peer_id).await;
+            replica_set.add_remote(peer_id).await?;
         }
+
+        Ok(())
     }
 
     pub fn delete(&self) -> Result<(), StorageError> {

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -2,10 +2,7 @@ use crate::{
     channel_service::ChannelService,
     error::{CollectionError, CollectionResult, StorageError},
     storage::{
-        replicas::{
-            local_shard::LocalShard, remote_shard::RemoteShard, ReplicaHolder, ReplicaSet,
-            ShardOperationTrait,
-        },
+        replicas::{local_shard::LocalShard, ReplicaHolder, ReplicaSet, ShardOperationTrait},
         segment::{Point, PointId},
     },
     types::{PeerId, ShardId},
@@ -58,6 +55,7 @@ impl Collection {
                 let replica_set = ReplicaSet::new(
                     LocalShard::init(shard_path, shard_id),
                     id.clone(),
+                    shard_id,
                     channel_service.clone(),
                 );
 
@@ -77,16 +75,8 @@ impl Collection {
     /// ToDo: Should only add a remote replica, but only for one shard at a time
     pub async fn add_remote_replicas(&self, peer_id: PeerId) {
         let mut replica_holder = self.replica_holder.write().await;
-        for (shard_id, replica_set) in replica_holder.shards.iter_mut() {
-            replica_set.remotes.insert(
-                peer_id,
-                RemoteShard::new(
-                    *shard_id,
-                    self.id.clone(),
-                    peer_id,
-                    self.channel_service.clone(),
-                ),
-            );
+        for (_shard_id, replica_set) in replica_holder.shards.iter_mut() {
+            replica_set.add_remote(peer_id).await;
         }
     }
 
@@ -147,7 +137,7 @@ impl Collection {
             replicas.insert(
                 shard_id,
                 // ToDo: Load remote shards if any
-                ReplicaSet::new(shard, id.clone(), channel_service.clone()),
+                ReplicaSet::new(shard, id.clone(), shard_id, channel_service.clone()),
             );
         }
 

--- a/src/storage/replicas/mod.rs
+++ b/src/storage/replicas/mod.rs
@@ -8,7 +8,6 @@ use crate::storage::segment::Point;
 use crate::storage::{collection::CollectionName, segment::PointId};
 use crate::types::{PeerId, ShardId};
 use futures::future::BoxFuture;
-use log::warn;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tonic::async_trait;
@@ -51,12 +50,12 @@ impl ReplicaSet {
     }
 
     /// Add a remote shard to the replica set
-    pub async fn add_remote(&mut self, peer_id: PeerId) {
+    pub async fn add_remote(&mut self, peer_id: PeerId) -> Result<(), StorageError> {
         if self.remotes.contains_key(&peer_id) {
-            warn!(
-                "Remote replica for shard {} at {peer_id} already exists in collection {}. But adding again.",
+            return Err(StorageError::BadInput(format!(
+                "Remote replica for shard {} at {peer_id} already exists in collection {}",
                 self.shard_id, self.collection_id
-            );
+            )));
         }
 
         let remote = RemoteShard::new(
@@ -66,6 +65,8 @@ impl ReplicaSet {
             self.channel_service.clone(),
         );
         self.remotes.insert(peer_id, remote);
+
+        Ok(())
     }
 
     pub fn num_replicas(&self) -> usize {

--- a/src/storage/replicas/mod.rs
+++ b/src/storage/replicas/mod.rs
@@ -8,6 +8,7 @@ use crate::storage::segment::Point;
 use crate::storage::{collection::CollectionName, segment::PointId};
 use crate::types::{PeerId, ShardId};
 use futures::future::BoxFuture;
+use log::warn;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tonic::async_trait;
@@ -27,8 +28,8 @@ pub struct ReplicaSet {
     pub local: LocalShard,
     pub remotes: HashMap<PeerId, RemoteShard>,
 
-    #[allow(dead_code)]
     collection_id: CollectionName,
+    shard_id: ShardId,
 
     channel_service: Arc<ChannelService>,
 }
@@ -37,21 +38,25 @@ impl ReplicaSet {
     pub fn new(
         local: LocalShard,
         collection_id: CollectionName,
+        shard_id: ShardId,
         channel_service: Arc<ChannelService>,
     ) -> Self {
         ReplicaSet {
             local,
             remotes: HashMap::new(),
             collection_id,
+            shard_id,
             channel_service,
         }
     }
 
-    pub async fn add_remote(&mut self, peer_id: PeerId) -> CollectionResult<()> {
+    /// Add a remote shard to the replica set
+    pub async fn add_remote(&mut self, peer_id: PeerId) {
         if self.remotes.contains_key(&peer_id) {
-            return Err(StorageError::BadInput(format!(
-                "Remote peer {peer_id} already exists"
-            )))?;
+            warn!(
+                "Remote replica for shard {} at {peer_id} already exists in collection {}. But adding again.",
+                self.shard_id, self.collection_id
+            );
         }
 
         let remote = RemoteShard::new(
@@ -61,7 +66,6 @@ impl ReplicaSet {
             self.channel_service.clone(),
         );
         self.remotes.insert(peer_id, remote);
-        Ok(())
     }
 
     pub fn num_replicas(&self) -> usize {
@@ -175,8 +179,8 @@ mod tests {
         let cs = Arc::new(ChannelService::default());
 
         let shard_holder = ReplicaHolder::new(HashMap::from_iter([
-            (0, ReplicaSet::new(s0, "c1".to_string(), cs.clone())),
-            (1, ReplicaSet::new(s1, "c1".to_string(), cs)),
+            (0, ReplicaSet::new(s0, "c1".to_string(), 0, cs.clone())),
+            (1, ReplicaSet::new(s1, "c1".to_string(), 1, cs)),
         ]));
 
         let shards_to_point_ids = shard_holder

--- a/src/storage/toc.rs
+++ b/src/storage/toc.rs
@@ -116,7 +116,7 @@ impl TableOfContent {
 
                 let remote_ids = self.channel_service.get_other_peer_ids().await;
                 for peer_id in remote_ids {
-                    collection.add_remote_replicas(peer_id).await;
+                    collection.add_remote_replicas(peer_id).await?;
                 }
 
                 {


### PR DESCRIPTION
Fix bug with remote shards. 

Did some other improvements too:
- Add `ShardId` to `ReplicaSet` for improved debugging
- Avoid adding remote replicas when processing `ConsensusOperation::AddPeer`