### PR TITLE
Fix remote shard bug with 3 nodes

### DIFF
--- a/src/api/dispatcher.rs
+++ b/src/api/dispatcher.rs
@@ -89,9 +89,10 @@ impl Dispatcher {
         });
 
         // Update local consensus state
-        // ToDo: Await Consensus::AddPeer consensus operation to be applied via ready_processor::handle_normal() to add remote replicas and other stuff instead of doing it forcefully here.
+        // Note that remote replicas will be added later when the consensus loop applies ConsensusOperation::AddPeer
+        // Handling this becomes cleaner once I build mechanism to wait for consensus operations to be applied
         let (this_peer_id, updated_peers) =
-            add_peer_to_toc_and_consensus_state(&consensus.state, &self.toc, peer_id, uri, true)
+            add_peer_to_toc_and_consensus_state(&consensus.state, &self.toc, peer_id, uri, false)
                 .await
                 .map_err(|e| {
                     ConsensusError::ServiceError(format!(

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -110,10 +110,10 @@ impl ConsensusState {
         persistent.peers.insert(peer_id, uri.to_string());
 
         // ToDo: Should return leader peer ID instead of current peer ID
-        let leader_peer_id = persistent.peer_id;
+        let this_peer_id = persistent.peer_id;
         let latest_peers = persistent.peers.clone().into_iter().collect();
 
-        Ok((leader_peer_id, latest_peers))
+        Ok((this_peer_id, latest_peers))
     }
 
     pub async fn get_peer_uri(&self, peer_id: PeerId) -> Result<Uri, ConsensusError> {

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -313,7 +313,7 @@ impl Consensus {
                                 );
                                 callbacks.insert(id, callback);
 
-                                // If add peer, first propose a conf change to the Raft node
+                                // If adding peer, first propose a ConfChange to the Raft node
                                 if let ConsensusOperation::AddPeer { peer_id, uri } = &operation {
                                     // ToDo: Use ConfChangeV2 instead
                                     let mut conf_change = ConfChange::default();
@@ -328,7 +328,7 @@ impl Consensus {
                                         .expect("Failed to propose conf change to add peer");
                                 }
 
-                                // Propose the operation to the Raft node log
+                                // Propose the operation to the Raft node log to be handled eventually by ready_processor
                                 let msg_bytes = operation.into_bytes();
                                 raft_node.propose(vec![], msg_bytes).unwrap();
                             }

--- a/src/consensus/ready_processor.rs
+++ b/src/consensus/ready_processor.rs
@@ -160,16 +160,9 @@ impl Consensus {
             ConsensusOperation::AddPeer { peer_id, uri } => {
                 let uri = uri.parse::<Uri>().expect("Failed to parse URI");
                 extra_runtime.spawn(async move {
-                    // We don't add remote replicas here because it was already done by ConfChange::AddNode
-                    add_peer_to_toc_and_consensus_state(
-                        &consensus_state,
-                        &toc,
-                        peer_id,
-                        uri,
-                        false,
-                    )
-                    .await
-                    .expect("Failed to add peer to consensus state and TOC");
+                    add_peer_to_toc_and_consensus_state(&consensus_state, &toc, peer_id, uri, true)
+                        .await
+                        .expect("Failed to add peer to consensus state and TOC");
                 })
             }
             ConsensusOperation::CollectionOp(op) => extra_runtime.spawn(async move {

--- a/src/consensus/utils.rs
+++ b/src/consensus/utils.rs
@@ -11,12 +11,9 @@ pub async fn add_peer_to_toc_and_consensus_state(
     uri: Uri,
     add_remote_replicas: bool,
 ) -> Result<(PeerId, Vec<(PeerId, String)>), ConsensusError> {
-    let (_leader_peer_id, all_peers) =
-        consensus_state.add_peer(peer_id, uri).await.map_err(|e| {
-            ConsensusError::ServiceError(format!(
-                "Failed to add peer to local consensus state: {e}"
-            ))
-        })?;
+    let (_this_peer_id, all_peers) = consensus_state.add_peer(peer_id, uri).await.map_err(|e| {
+        ConsensusError::ServiceError(format!("Failed to add peer to local consensus state: {e}"))
+    })?;
 
     if add_remote_replicas {
         let collections = toc.collections.read().await;

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -76,7 +76,7 @@ impl Collection {
     pub async fn add_remote_replicas(&self, peer_id: PeerId) -> Result<(), StorageError> {
         let mut replica_holder = self.replica_holder.write().await;
         for (_shard_id, replica_set) in replica_holder.shards.iter_mut() {
-            replica_set.add_remote(peer_id).await?;
+            replica_set.add_remote(peer_id).await;
         }
 
         Ok(())

--- a/src/storage/replicas/mod.rs
+++ b/src/storage/replicas/mod.rs
@@ -8,6 +8,7 @@ use crate::storage::segment::Point;
 use crate::storage::{collection::CollectionName, segment::PointId};
 use crate::types::{PeerId, ShardId};
 use futures::future::BoxFuture;
+use log::warn;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tonic::async_trait;
@@ -50,12 +51,18 @@ impl ReplicaSet {
     }
 
     /// Add a remote shard to the replica set
-    pub async fn add_remote(&mut self, peer_id: PeerId) -> Result<(), StorageError> {
+    pub async fn add_remote(&mut self, peer_id: PeerId) {
+        if peer_id == self.channel_service.peer_id {
+            warn!("Cannot add local shard as remote replica: {peer_id}");
+            return;
+        }
+
         if self.remotes.contains_key(&peer_id) {
-            return Err(StorageError::BadInput(format!(
+            warn!(
                 "Remote replica for shard {} at {peer_id} already exists in collection {}",
                 self.shard_id, self.collection_id
-            )));
+            );
+            return;
         }
 
         let remote = RemoteShard::new(
@@ -65,8 +72,6 @@ impl ReplicaSet {
             self.channel_service.clone(),
         );
         self.remotes.insert(peer_id, remote);
-
-        Ok(())
     }
 
     pub fn num_replicas(&self) -> usize {


### PR DESCRIPTION
smoldb had a problem that when you create a cluster with 3 nodes: 100, 101, 102

The 2nd one (101) will NOT have remote replicas for peer 102 on adding peer.

This fix is still hacky. I need to build a mechanism to wait for consensus operations in a clean way. 