### PR TITLE
Introduce filtering support with new query API

### DIFF
--- a/benches/read_write.rs
+++ b/benches/read_write.rs
@@ -31,6 +31,7 @@ pub fn single_write(c: &mut Criterion) {
             "test_collection".to_string(),
             CollectionConfig {
                 params: "...".to_string(),
+                payload_schema: Default::default(),
             },
             tempdir.path(),
             channel_service.clone(),
@@ -74,6 +75,7 @@ pub fn concurrent_write(c: &mut Criterion) {
             "test_collection".to_string(),
             CollectionConfig {
                 params: "...".to_string(),
+                payload_schema: Default::default(),
             },
             tempdir.path(),
             channel_service,
@@ -127,6 +129,7 @@ pub fn single_read(c: &mut Criterion) {
             "test_collection".to_string(),
             CollectionConfig {
                 params: "...".to_string(),
+                payload_schema: Default::default(),
             },
             tempdir.path(),
             channel_service,
@@ -190,6 +193,7 @@ fn concurrent_read(c: &mut Criterion) {
             "test_collection".to_string(),
             CollectionConfig {
                 params: "...".to_string(),
+                payload_schema: Default::default(),
             },
             tempdir.path(),
             channel_service,

--- a/src/api/collection.rs
+++ b/src/api/collection.rs
@@ -1,7 +1,7 @@
 use crate::api::dispatcher::Dispatcher;
 use crate::api::helpers;
 use crate::error::CollectionError;
-use crate::storage::collection::{Collection, CollectionInfo};
+use crate::storage::collection::{Collection, CollectionConfig, CollectionInfo};
 use crate::storage::replicas::ShardState;
 use crate::storage::toc::CollectionOperation;
 use crate::types::{PeerId, ShardId};
@@ -9,7 +9,7 @@ use actix_web::{
     web::{self, Json},
     Responder,
 };
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 #[actix_web::get("/collections")]
 async fn get_collections(dispatcher: web::Data<Dispatcher>) -> impl Responder {
@@ -154,15 +154,10 @@ async fn get_collection_cluster_info(
     .await
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct CreateCollection {
-    pub params: String,
-}
-
 #[actix_web::put("/collections/{collection_name}")]
 async fn create_collection(
     collection_name: web::Path<String>,
-    operation: Json<CreateCollection>,
+    config: Json<CollectionConfig>,
     dispatcher: web::Data<Dispatcher>,
 ) -> impl Responder {
     helpers::time(async {
@@ -171,7 +166,7 @@ async fn create_collection(
         dispatcher
             .submit_collection_op(CollectionOperation::CreateCollection {
                 collection_name: collection_name.clone(),
-                params: operation.params.clone(),
+                config: config.into_inner(),
             })
             .await?;
 

--- a/src/api/points.rs
+++ b/src/api/points.rs
@@ -1,7 +1,10 @@
 use crate::{
     api::{dispatcher::Dispatcher, helpers},
     error::CollectionError,
-    storage::segment::{Point, PointId},
+    storage::{
+        index::filter::QueryFilter,
+        segment::{Point, PointId},
+    },
 };
 use actix_web::{
     web::{self, Json},
@@ -95,8 +98,41 @@ async fn list_points(
     dispatcher: web::Data<Dispatcher>,
 ) -> impl Responder {
     helpers::time(async {
-        let collection_name = collection_name.into_inner();
+        let collection_name: String = collection_name.into_inner();
         let result = dispatcher.toc.read_points(&collection_name, None).await;
+        match result {
+            Ok(points) => {
+                if points.is_empty() {
+                    Err(CollectionError::ServiceError(format!(
+                        "No points found in collection '{collection_name}'"
+                    )))
+                } else {
+                    Ok(ListPointsResponse { points })
+                }
+            }
+            Err(e) => Err(CollectionError::ServiceError(format!(
+                "Error listing points in collection '{collection_name}': {e}"
+            ))),
+        }
+    })
+    .await
+}
+
+#[derive(Deserialize, Clone)]
+pub struct Query {
+    pub filter: QueryFilter,
+}
+
+#[actix_web::post("/collections/{collection_name}/query")]
+async fn query_points(
+    collection_name: web::Path<String>,
+    dispatcher: web::Data<Dispatcher>,
+    query: Json<Query>,
+) -> impl Responder {
+    helpers::time(async {
+        let collection_name: String = collection_name.into_inner();
+        let query = query.into_inner();
+        let result = dispatcher.toc.query_points(&collection_name, query).await;
         match result {
             Ok(points) => {
                 if points.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use crate::api::{
         get_collections,
     },
     dispatcher::Dispatcher,
-    points::{get_point, list_points, upsert_points},
+    points::{get_point, list_points, query_points, upsert_points},
 };
 use crate::channel_service::ChannelService;
 use crate::consensus::{manager::ConsensusManager, Consensus, ConsensusState};
@@ -48,6 +48,7 @@ async fn start_http_server(url: Uri, dispatcher: Arc<Dispatcher>) -> std::io::Re
             .service(upsert_points)
             .service(get_point)
             .service(list_points)
+            .service(query_points)
             .app_data(dispatcher_app_data.clone())
     })
     .bind((host, port))?

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -1,7 +1,9 @@
 use crate::{
+    api::points::Query,
     channel_service::ChannelService,
     error::{CollectionError, CollectionResult, StorageError},
     storage::{
+        index::payload_index::IndexConfig,
         replicas::{
             local_shard::LocalShard, ReplicaHolder, ReplicaSet, ShardOperationTrait, ShardState,
         },
@@ -56,7 +58,7 @@ impl Collection {
                 let shard_id = shard_id as ShardId;
                 // No remote replicas initially. They will be added by Collection::add_remote_replicas
                 let replica_set = ReplicaSet::new(
-                    LocalShard::init(shard_path, shard_id),
+                    LocalShard::init(shard_path, shard_id, Some(config.payload_schema.clone())),
                     id.clone(),
                     shard_id,
                     channel_service.clone(),
@@ -304,11 +306,26 @@ impl Collection {
             Ok(points)
         }
     }
+
+    pub async fn query_points(&self, query: Query) -> CollectionResult<Vec<Point>> {
+        let replica_holder = self.replica_holder.read().await;
+
+        let mut results = vec![];
+        for (_shard_id, replica_set) in replica_holder.shards.iter() {
+            let shard_results = replica_set.local.query_points(query.clone()).await?;
+            results.extend(shard_results);
+        }
+
+        // ToDo: Implement cluster level query
+
+        Ok(results)
+    }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CollectionConfig {
     pub params: String,
+    pub payload_schema: BTreeMap<String, IndexConfig>,
 }
 
 impl CollectionConfig {

--- a/src/storage/index/filter.rs
+++ b/src/storage/index/filter.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterOperation {
+    Gte,
+    Eq,
+    Lte,
+    Gt,
+    Lt,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct QueryFilter {
+    pub key: String,
+    pub value: String,
+    pub operation: FilterOperation,
+}

--- a/src/storage/index/filter.rs
+++ b/src/storage/index/filter.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
-pub enum FilterOperation {
+pub enum FilterOperator {
     Gte,
     Eq,
     Lte,
@@ -14,5 +14,5 @@ pub enum FilterOperation {
 pub struct QueryFilter {
     pub key: String,
     pub value: String,
-    pub operation: FilterOperation,
+    pub operator: FilterOperator,
 }

--- a/src/storage/index/filter.rs
+++ b/src/storage/index/filter.rs
@@ -14,5 +14,5 @@ pub enum FilterOperator {
 pub struct QueryFilter {
     pub key: String,
     pub value: String,
-    pub operator: FilterOperator,
+    pub op: FilterOperator,
 }

--- a/src/storage/index/mod.rs
+++ b/src/storage/index/mod.rs
@@ -1,1 +1,2 @@
+pub mod filter;
 pub mod payload_index;

--- a/src/storage/index/payload_index.rs
+++ b/src/storage/index/payload_index.rs
@@ -1,12 +1,21 @@
-use crate::storage::segment::{Point, PointId};
+use crate::{
+    api::points::Query,
+    storage::{
+        index::filter::FilterOperation,
+        segment::{Point, PointId},
+    },
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sled::Db;
-use std::collections::HashMap;
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Bound,
+};
 
 /// Converts the number into a big-endian value which is suitable for querying/storing in sled
 /// This allows lexicographical ordering and hence numeric comparisons
-fn encoded_payload_value(n: u64) -> Vec<u8> {
+fn encoded_integer_value(n: i64) -> Vec<u8> {
     n.to_be_bytes().to_vec()
 }
 
@@ -29,7 +38,7 @@ impl IntegerIndex {
 
     pub fn upsert(&self, point_id: u64, value: i64) -> Result<(), sled::Error> {
         // In numeric tree, the point value becomes tree's key, and the point ID is part of a list of values.
-        let tree_key = encoded_payload_value(value as u64);
+        let tree_key = encoded_integer_value(value);
 
         // Fetch existing point IDs for this value
         let mut point_ids: Vec<u64> = self
@@ -61,11 +70,24 @@ impl IntegerIndex {
         Ok(())
     }
 
-    pub fn query_gte(&self, value: i64) -> Result<Vec<PointId>, sled::Error> {
-        let min_key = encoded_payload_value(value as u64);
-
+    pub fn query(
+        &self,
+        value: i64,
+        operation: &FilterOperation,
+    ) -> Result<Vec<PointId>, sled::Error> {
         let mut results = Vec::new();
-        for item in self.0.range(min_key..) {
+
+        let value = encoded_integer_value(value);
+
+        let bounds = match operation {
+            FilterOperation::Gte => (Bound::Included(value), Bound::Unbounded),
+            FilterOperation::Gt => (Bound::Excluded(value), Bound::Unbounded),
+            FilterOperation::Lt => (Bound::Unbounded, Bound::Excluded(value)),
+            FilterOperation::Lte => (Bound::Unbounded, Bound::Included(value)),
+            FilterOperation::Eq => (Bound::Included(value.clone()), Bound::Included(value)),
+        };
+
+        for item in self.0.range(bounds) {
             let (_gte_value, encoded_point_ids) = item?;
             let point_ids = decoded_point_ids(&encoded_point_ids).map_err(|e| {
                 sled::Error::Io(std::io::Error::other(format!("Failed to decode: {e}")))
@@ -103,7 +125,7 @@ impl FieldIndex {
                 }
                 _ => Err(sled::Error::Io(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    "Not a valid i64 value",
+                    format!("{value} is not a valid i64 value"),
                 ))),
             },
             FieldIndex::Null => {
@@ -202,6 +224,25 @@ impl PayloadIndex {
         }
         Ok(())
     }
+
+    pub fn query(&self, query: Query) -> Result<Vec<PointId>, sled::Error> {
+        let mut results = HashSet::new();
+        for (index_name, index) in &self.indices {
+            if *index_name == query.filter.key {
+                match index {
+                    FieldIndex::Int(int_index) => {
+                        let value = query.filter.value.parse::<i64>().unwrap();
+                        let query_results = int_index.query(value, &query.filter.operation)?;
+                        results.extend(query_results);
+                    }
+                    FieldIndex::Null => {
+                        unimplemented!("Null index queries are not implemented yet");
+                    }
+                }
+            }
+        }
+        Ok(results.into_iter().collect())
+    }
 }
 
 #[cfg(test)]
@@ -231,7 +272,7 @@ mod test {
         let field_index = index.indices.get("price").unwrap();
 
         if let FieldIndex::Int(numeric_index) = field_index {
-            let results = numeric_index.query_gte(40).unwrap();
+            let results = numeric_index.query(40, &FilterOperation::Gte).unwrap();
             assert_eq!(results.len(), 6); // Points with ids 4, 5, 6, 7, 8, 9
             assert_eq!(results, (4..10).map(PointId::Id).collect::<Vec<_>>());
         } else {

--- a/src/storage/index/payload_index.rs
+++ b/src/storage/index/payload_index.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::points::Query,
     storage::{
-        index::filter::FilterOperation,
+        index::filter::FilterOperator,
         segment::{Point, PointId},
     },
 };
@@ -73,18 +73,18 @@ impl IntegerIndex {
     pub fn query(
         &self,
         value: i64,
-        operation: &FilterOperation,
+        operation: &FilterOperator,
     ) -> Result<Vec<PointId>, sled::Error> {
         let mut results = Vec::new();
 
         let value = encoded_integer_value(value);
 
         let bounds = match operation {
-            FilterOperation::Gte => (Bound::Included(value), Bound::Unbounded),
-            FilterOperation::Gt => (Bound::Excluded(value), Bound::Unbounded),
-            FilterOperation::Lt => (Bound::Unbounded, Bound::Excluded(value)),
-            FilterOperation::Lte => (Bound::Unbounded, Bound::Included(value)),
-            FilterOperation::Eq => (Bound::Included(value.clone()), Bound::Included(value)),
+            FilterOperator::Gte => (Bound::Included(value), Bound::Unbounded),
+            FilterOperator::Gt => (Bound::Excluded(value), Bound::Unbounded),
+            FilterOperator::Lt => (Bound::Unbounded, Bound::Excluded(value)),
+            FilterOperator::Lte => (Bound::Unbounded, Bound::Included(value)),
+            FilterOperator::Eq => (Bound::Included(value.clone()), Bound::Included(value)),
         };
 
         for item in self.0.range(bounds) {
@@ -232,7 +232,7 @@ impl PayloadIndex {
                 match index {
                     FieldIndex::Int(int_index) => {
                         let value = query.filter.value.parse::<i64>().unwrap();
-                        let query_results = int_index.query(value, &query.filter.operation)?;
+                        let query_results = int_index.query(value, &query.filter.operator)?;
                         results.extend(query_results);
                     }
                     FieldIndex::Null => {
@@ -272,7 +272,7 @@ mod test {
         let field_index = index.indices.get("price").unwrap();
 
         if let FieldIndex::Int(numeric_index) = field_index {
-            let results = numeric_index.query(40, &FilterOperation::Gte).unwrap();
+            let results = numeric_index.query(40, &FilterOperator::Gte).unwrap();
             assert_eq!(results.len(), 6); // Points with ids 4, 5, 6, 7, 8, 9
             assert_eq!(results, (4..10).map(PointId::Id).collect::<Vec<_>>());
         } else {

--- a/src/storage/index/payload_index.rs
+++ b/src/storage/index/payload_index.rs
@@ -232,7 +232,7 @@ impl PayloadIndex {
                 match index {
                     FieldIndex::Int(int_index) => {
                         let value = query.filter.value.parse::<i64>().unwrap();
-                        let query_results = int_index.query(value, &query.filter.operator)?;
+                        let query_results = int_index.query(value, &query.filter.op)?;
                         results.extend(query_results);
                     }
                     FieldIndex::Null => {

--- a/src/storage/replicas/local_shard.rs
+++ b/src/storage/replicas/local_shard.rs
@@ -1,12 +1,17 @@
 use crate::{
+    api::points::Query,
     error::{CollectionError, CollectionResult, StorageError},
     storage::{
+        index::payload_index::IndexConfig,
         replicas::{ShardOperationTrait, ShardState},
         segment::{Point, PointId, Segment},
     },
     types::{SegmentId, ShardId},
 };
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+};
 use tonic::async_trait;
 
 const SEGMENTS_DIR: &str = "segments";
@@ -46,14 +51,35 @@ impl ShardOperationTrait for LocalShard {
             ))
         }
     }
+
+    async fn query_points(&self, query: Query) -> CollectionResult<Vec<Point>> {
+        if let Some(segment) = self.segments.get(&0) {
+            segment.query_points(query).map_err(|e| {
+                CollectionError::StorageError(StorageError::ServiceError(format!(
+                    "Failed to query points from segment: {e}"
+                )))
+            })
+        } else {
+            Err(StorageError::ServiceError(
+                "No segments available".to_string(),
+            ))?
+        }
+    }
 }
 
 impl LocalShard {
-    pub fn init(path: PathBuf, id: ShardId) -> Self {
+    pub fn init(
+        path: PathBuf,
+        id: ShardId,
+        payload_schema: Option<BTreeMap<String, IndexConfig>>,
+    ) -> Self {
         let segments_dir = path.join(SEGMENTS_DIR);
         std::fs::create_dir_all(&segments_dir).expect("Failed to create segments directory");
 
-        let segment0 = Segment::create(&segments_dir).expect("Failed to create initial segment");
+        let payload_schema = payload_schema.unwrap_or_default();
+
+        let segment0 = Segment::create(&segments_dir, payload_schema)
+            .expect("Failed to create initial segment");
 
         LocalShard {
             id,

--- a/src/storage/replicas/mod.rs
+++ b/src/storage/replicas/mod.rs
@@ -1,6 +1,7 @@
 pub mod local_shard;
 pub mod remote_shard;
 
+use crate::api::points::Query;
 use crate::channel_service::ChannelService;
 use crate::error::{CollectionResult, StorageError};
 use crate::storage::replicas::{local_shard::LocalShard, remote_shard::RemoteShard};
@@ -23,6 +24,7 @@ pub struct UpdateResult {
 pub trait ShardOperationTrait {
     async fn get_points(&self, ids: Option<Vec<PointId>>) -> CollectionResult<Vec<Point>>;
     async fn upsert_points(&self, points: Vec<Point>) -> CollectionResult<()>;
+    async fn query_points(&self, query: Query) -> CollectionResult<Vec<Point>>;
 }
 
 #[derive(Serialize, PartialEq, Debug, Clone)]
@@ -228,8 +230,8 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
 
         let peer_id: PeerId = 100;
-        let s0 = LocalShard::init(tmp_dir.path().join("0"), 0);
-        let s1 = LocalShard::init(tmp_dir.path().join("1"), 1);
+        let s0 = LocalShard::init(tmp_dir.path().join("0"), 0, None);
+        let s1 = LocalShard::init(tmp_dir.path().join("1"), 1, None);
 
         let cs = Arc::new(ChannelService::empty(peer_id));
 

--- a/src/storage/replicas/remote_shard.rs
+++ b/src/storage/replicas/remote_shard.rs
@@ -1,7 +1,10 @@
 use crate::{
-    api::grpc::schema::{
-        points_internal_client::PointsInternalClient, GetPointsRequest, Point as PointGrpc,
-        UpsertPointsRequest,
+    api::{
+        grpc::schema::{
+            points_internal_client::PointsInternalClient, GetPointsRequest, Point as PointGrpc,
+            UpsertPointsRequest,
+        },
+        points::Query,
     },
     channel_service::ChannelService,
     error::{CollectionError, CollectionResult},
@@ -139,5 +142,12 @@ impl ShardOperationTrait for RemoteShard {
             .into_inner();
 
         Ok(()) // Placeholder for actual remote shard logic
+    }
+
+    async fn query_points(&self, _query: Query) -> CollectionResult<Vec<Point>> {
+        // Remote shard does not support querying yet
+        Err(CollectionError::ServiceError(
+            "Remote shard does not support querying points".to_string(),
+        ))
     }
 }

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -1,6 +1,13 @@
-use crate::{error::StorageError, storage::index::payload_index::PayloadIndex};
+use crate::{
+    api::points::Query,
+    error::StorageError,
+    storage::index::payload_index::{IndexConfig, PayloadIndex},
+};
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Debug)]
 #[serde(untagged)]
@@ -32,7 +39,10 @@ pub struct Segment {
 }
 
 impl Segment {
-    pub fn create(segments_dir: &Path) -> Result<Self, StorageError> {
+    pub fn create(
+        segments_dir: &Path,
+        payload_schema: BTreeMap<String, IndexConfig>,
+    ) -> Result<Self, StorageError> {
         // ToDo: Have uuid segment ID
         let path = segments_dir.join("0");
         std::fs::create_dir_all(&path).expect("Failed to create segment directory");
@@ -41,7 +51,13 @@ impl Segment {
             StorageError::ServiceError(format!("Failed to open segment database: {e}"))
         })?;
 
-        let payload_index = PayloadIndex::get_or_create(&db);
+        let mut payload_index = PayloadIndex::get_or_create(&db);
+
+        for (index_name, index_config) in payload_schema {
+            payload_index
+                .add_index(&db, &index_name, index_config)
+                .map_err(|e| StorageError::ServiceError(format!("Failed to add index: {e}")))?;
+        }
 
         Ok(Self {
             path,
@@ -123,6 +139,15 @@ impl Segment {
                 points.push(point);
             }
         }
+        Ok(points)
+    }
+
+    pub fn query_points(&self, query: Query) -> Result<Vec<Point>, StorageError> {
+        let point_ids = self.payload_index.query(query).map_err(|e| {
+            StorageError::ServiceError(format!("Failed to query payload index: {e}"))
+        })?;
+        let points = self.get_points(Some(point_ids))?;
+
         Ok(points)
     }
 

--- a/src/storage/toc.rs
+++ b/src/storage/toc.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::points::PointsOperation,
+    api::points::{PointsOperation, Query},
     channel_service::ChannelService,
     error::StorageError,
     storage::{
@@ -25,7 +25,7 @@ pub struct TableOfContent {
 pub enum CollectionOperation {
     CreateCollection {
         collection_name: String,
-        params: String,
+        config: CollectionConfig,
     },
     DeleteCollection {
         collection_name: String,
@@ -101,14 +101,14 @@ impl TableOfContent {
         match operation {
             CollectionOperation::CreateCollection {
                 collection_name,
-                params,
+                config,
             } => {
                 println!("Creating collection {collection_name}");
                 let path = Self::mkdir_collection_dir(&collection_name).await?;
 
                 let collection = Collection::init(
                     collection_name.clone(),
-                    CollectionConfig { params },
+                    config,
                     &path,
                     self.channel_service.clone(),
                 )
@@ -188,6 +188,23 @@ impl TableOfContent {
         collection.read_points(ids, None, false).await.map_err(|e| {
             StorageError::ServiceError(format!(
                 "Failed to read points from collection '{collection_name}': {e}"
+            ))
+        })
+    }
+
+    pub async fn query_points(
+        &self,
+        collection_name: &str,
+        query: Query,
+    ) -> Result<Vec<Point>, StorageError> {
+        let collections = self.collections.read().await;
+        let collection = collections.get(collection_name).ok_or_else(|| {
+            StorageError::BadInput(format!("Collection '{collection_name}' does not exist"))
+        })?;
+
+        collection.query_points(query).await.map_err(|e| {
+            StorageError::ServiceError(format!(
+                "Failed to query points in collection '{collection_name}': {e}"
             ))
         })
     }

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -60,7 +60,7 @@ async fn get_cluster_info(url: &Uri) -> Result<ApiResponse<Value>, SmolBenchErro
 pub async fn create_collection(
     url: &Uri,
     collection_name: &str,
-    skip_int_index: &bool,
+    skip_int_index: bool,
     wait: bool,
 ) -> Result<ApiSuccessResponse<bool>, SmolBenchError> {
     // First ensure that consensus is started
@@ -68,7 +68,7 @@ pub async fn create_collection(
 
     let client = reqwest::Client::new();
 
-    let payload_schema = if *skip_int_index {
+    let payload_schema = if skip_int_index {
         json!({})
     } else {
         json!({

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -60,6 +60,7 @@ async fn get_cluster_info(url: &Uri) -> Result<ApiResponse<Value>, SmolBenchErro
 pub async fn create_collection(
     url: &Uri,
     collection_name: &str,
+    skip_int_index: &bool,
     wait: bool,
 ) -> Result<ApiSuccessResponse<bool>, SmolBenchError> {
     // First ensure that consensus is started
@@ -67,10 +68,19 @@ pub async fn create_collection(
 
     let client = reqwest::Client::new();
 
+    let payload_schema = if *skip_int_index {
+        json!({})
+    } else {
+        json!({
+            "price": "int"
+        })
+    };
+
     let res = client
         .put(format!("{url}/collections/{collection_name}"))
         .json(&serde_json::json!({
-            "params": "..."
+            "params": "...",
+            "payload_schema": payload_schema,
         }))
         .send()
         .await?;
@@ -215,6 +225,7 @@ pub async fn upsert_points(
                 payload: json!({
                     "text": format!("Point {}", i),
                     "timestamp": batch_ts.to_rfc3339(),
+                    "price": i as i64 * 10,
                 }),
             })
             .collect();

--- a/tools/smolbench/src/args.rs
+++ b/tools/smolbench/src/args.rs
@@ -55,6 +55,10 @@ pub struct Args {
     #[clap(long, default_value = "false")]
     pub skip_if_exists: bool,
 
+    /// Use integer index for payload
+    #[clap(long, default_value = "false")]
+    pub skip_int_index: bool,
+
     /// Use if you don't want to upsert points by default
     #[clap(long, default_value = "false")]
     pub skip_upsert: bool,

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -35,7 +35,14 @@ async fn main() -> Result<(), SmolBenchError> {
                     args.collection_name
                 );
                 delete_collection(&args.uri, &args.collection_name, true).await?;
-                match create_collection(&args.uri, &args.collection_name, true).await {
+                match create_collection(
+                    &args.uri,
+                    &args.collection_name,
+                    &args.skip_int_index,
+                    true,
+                )
+                .await
+                {
                     Ok(_) => println!("Collection created successfully."),
                     Err(e) => return Err(SmolBenchError::CreateCollectionError(e.to_string()))?,
                 }
@@ -45,7 +52,9 @@ async fn main() -> Result<(), SmolBenchError> {
                 "Collection '{}' does not exist, creating it",
                 args.collection_name
             );
-            match create_collection(&args.uri, &args.collection_name, true).await {
+            match create_collection(&args.uri, &args.collection_name, &args.skip_int_index, true)
+                .await
+            {
                 Ok(_) => println!("Collection created successfully."),
                 Err(e) => return Err(SmolBenchError::CreateCollectionError(e.to_string()))?,
             }

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -35,13 +35,8 @@ async fn main() -> Result<(), SmolBenchError> {
                     args.collection_name
                 );
                 delete_collection(&args.uri, &args.collection_name, true).await?;
-                match create_collection(
-                    &args.uri,
-                    &args.collection_name,
-                    &args.skip_int_index,
-                    true,
-                )
-                .await
+                match create_collection(&args.uri, &args.collection_name, args.skip_int_index, true)
+                    .await
                 {
                     Ok(_) => println!("Collection created successfully."),
                     Err(e) => return Err(SmolBenchError::CreateCollectionError(e.to_string()))?,
@@ -52,7 +47,7 @@ async fn main() -> Result<(), SmolBenchError> {
                 "Collection '{}' does not exist, creating it",
                 args.collection_name
             );
-            match create_collection(&args.uri, &args.collection_name, &args.skip_int_index, true)
+            match create_collection(&args.uri, &args.collection_name, args.skip_int_index, true)
                 .await
             {
                 Ok(_) => println!("Collection created successfully."),

--- a/tools/smolbench/src/tests/mod.rs
+++ b/tools/smolbench/src/tests/mod.rs
@@ -16,7 +16,8 @@ async fn test_smoldb_consecutive_writes() -> Result<(), crate::error::SmolBenchE
     let batch_size: usize = 100;
     let delay = None;
 
-    let create_response = crate::apis::create_collection(&uri, &collection_name, true).await?;
+    let create_response =
+        crate::apis::create_collection(&uri, &collection_name, false, true).await?;
 
     println!("Result: {}", &create_response.result);
     assert!(create_response.result);


### PR DESCRIPTION
Now you can do  filtering like this:

```http
POST /collections/{name}/query
{
  "filter": {
    "key": "price",
    "value": "10",
    "op": "gte"
  }
}

## response:

{
  "result": {
    "points": [
      {
        "id": 4,
        "payload": {
          "price": 40,
          "text": "Point 4",
          "timestamp": "2025-08-02T10:54:22.686769374+00:00"
        }
      },
      {
        "id": 9,
        "payload": {
          "price": 90,
          "text": "Point 9",
          "timestamp": "2025-08-02T10:54:22.686769374+00:00"
        }
      }
    ]
  },
  "time": 0.000335412
}
```

Also extend filtering types to support `Gt,Lt, Lte, Eq`