### PR TITLE
smolbench: query concurrently to speed up benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,6 +2775,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "futures",
  "http 1.3.1",
  "indicatif",
  "rand 0.9.1",

--- a/tools/smolbench/Cargo.toml
+++ b/tools/smolbench/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.41"
 clap = { version = "4.5.38", features = ["derive"] }
+futures = "0.3.31"
 http = "1.3.1"
 indicatif = "0.18.0"
 rand = "0.9.1"

--- a/tools/smolbench/src/args.rs
+++ b/tools/smolbench/src/args.rs
@@ -79,6 +79,10 @@ pub struct Args {
     /// Delay between requests (batches) in milliseconds
     #[clap(short, long, default_value = None, value_parser = parse_number)]
     pub delay: Option<usize>,
+
+    /// Number of concurrent queries to run
+    #[clap(long, default_value = "10", value_parser = parse_number)]
+    pub concurrent_queries: usize,
 }
 
 pub fn parse_args() -> Args {

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -13,6 +13,10 @@ use crate::{
 };
 use args::parse_args;
 use error::SmolBenchError;
+use futures::{
+    stream::{self, StreamExt},
+    TryStreamExt,
+};
 use rand::Rng;
 use serde_json::json;
 
@@ -92,33 +96,35 @@ async fn main() -> Result<(), SmolBenchError> {
     }
 
     if !args.skip_query {
-        let num_queries = args.num_points.min(1000) as u64;
+        let num_queries = args.num_points.min(100) as u64;
         let mut rnd = rand::rng();
-        let price_gte = (0..num_queries)
-            .map(|_| rnd.random::<i64>() % args.num_points as i64)
+
+        let futures = (0..num_queries)
+            .map(|_| {
+                let price_gte = rnd.random::<i64>() % args.num_points as i64;
+                apis::query_points(
+                    &args.uri,
+                    &args.collection_name,
+                    json!({
+                        "filter": {
+                            "key": "price",
+                            "value": format!("{}", price_gte * 10),
+                            "op": "gte",
+                        }
+                    }),
+                )
+            })
             .collect::<Vec<_>>();
 
-        let mut responses = vec![];
-
-        for price_gte in price_gte {
-            let response = apis::query_points(
-                &args.uri,
-                &args.collection_name,
-                json!({
-                    "filter": {
-                        "key": "price",
-                        "value": format!("{}", price_gte * 10),
-                        "op": "gte",
-                    }
-                }),
-            )
+        let responses = stream::iter(futures)
+            .buffered(args.concurrent_queries)
+            .try_collect::<Vec<_>>()
             .await?;
-            responses.push(response);
-        }
 
         println!(
-            "Queried {} points from collection '{}' with price filter",
+            "Queried {} points with concurrency of {} from collection '{}' with price filter",
             responses.len(),
+            args.concurrent_queries,
             args.collection_name,
         );
 


### PR DESCRIPTION
Now we 10 query (filtering benchmark) by default. 

It can be changed passing `--concurrent-queries <number>`

Also do only 100 queries instead of 1000.