### PR TITLE
Collection and points methods improvements

### DIFF
--- a/src/api/points.rs
+++ b/src/api/points.rs
@@ -17,10 +17,6 @@ pub struct UpsertPoints {
     pub points: Vec<Point>,
 }
 
-pub enum PointsOperation {
-    Upsert(UpsertPoints),
-}
-
 #[derive(serde::Serialize)]
 pub struct UpsertPointsResponse {
     pub num_points: usize,
@@ -38,13 +34,17 @@ async fn upsert_points(
 
         let num_points = operation.points.len();
 
-        // ToDo: Return Created() or BadRequest() in HttpResponse?
-        let _result = dispatcher
+        let result = dispatcher
             .toc
-            .perform_points_op(&collection_name, PointsOperation::Upsert(operation))
-            .await?;
+            .upsert_points(&collection_name, operation.points)
+            .await;
 
-        Ok(UpsertPointsResponse { num_points })
+        match result {
+            Ok(()) => Ok(UpsertPointsResponse { num_points }),
+            Err(e) => Err(CollectionError::ServiceError(format!(
+                "Error upserting points in collection '{collection_name}': {e}"
+            ))),
+        }
     })
     .await
 }

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -375,3 +375,168 @@ impl CollectionInfo {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::index::filter::{FilterOperator, QueryFilter};
+
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn test_collection_init() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
+        let path = temp_dir.path();
+        let collection_name = "test_collection".to_string();
+        let config = CollectionConfig {
+            params: "test_params".to_string(),
+            payload_schema: BTreeMap::new(),
+        };
+
+        let collection = Collection::init(
+            collection_name,
+            config,
+            path,
+            Arc::new(ChannelService::empty(100)),
+        )
+        .await
+        .expect("Failed to initialize collection");
+
+        let config_path = path.join("config.json");
+
+        assert_eq!(collection.id, "test_collection");
+        assert!(collection.path.exists());
+        assert!(config_path.exists());
+
+        let replica_holder = collection.replica_holder.read().await;
+        assert_eq!(replica_holder.shards.len(), 2);
+        assert_eq!(replica_holder.shards[&0].remotes.len(), 0);
+        assert_eq!(replica_holder.shards[&1].remotes.len(), 0);
+
+        let shard0_dir = path.join("0");
+        let shard1_dir = path.join("1");
+        assert!(shard0_dir.exists());
+        assert!(shard1_dir.exists());
+    }
+
+    #[test]
+    fn test_collection_config_save() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
+        let path = temp_dir.path();
+        let config = CollectionConfig {
+            params: "test_params".to_string(),
+            payload_schema: BTreeMap::new(),
+        };
+
+        config
+            .save(&path)
+            .expect("Failed to save collection config");
+
+        let config_path = path.join(COLLECTION_CONFIG_FILE);
+        assert!(config_path.exists());
+        let loaded_config: CollectionConfig = serde_json::from_reader(
+            std::fs::File::open(config_path).expect("Failed to open config file"),
+        )
+        .expect("Failed to parse collection config JSON");
+
+        assert_eq!(loaded_config.params, config.params);
+        assert_eq!(loaded_config.payload_schema, config.payload_schema);
+    }
+
+    #[tokio::test]
+    async fn test_collection_load() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
+        let path = temp_dir.path();
+        let collection_name = "test_collection".to_string();
+        let config = CollectionConfig {
+            params: "test_params".to_string(),
+            payload_schema: BTreeMap::from_iter([
+                ("field1".to_string(), IndexConfig::Int),
+                ("field2".to_string(), IndexConfig::Null),
+            ]),
+        };
+
+        config
+            .save(&path)
+            .expect("Failed to save collection config");
+
+        let collection = Collection::load(
+            collection_name.clone(),
+            &path,
+            Arc::new(ChannelService::empty(100)),
+        )
+        .expect("Failed to load collection");
+
+        assert_eq!(collection.id, collection_name);
+        assert_eq!(collection.config.params, config.params);
+        assert_eq!(collection.config.payload_schema, config.payload_schema);
+    }
+
+    #[tokio::test]
+    async fn test_collection_write_read_points() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
+        let path = temp_dir.path();
+        let collection_name = "test_collection".to_string();
+
+        let config = CollectionConfig {
+            params: "test_params".to_string(),
+            payload_schema: BTreeMap::from_iter([("age".to_string(), IndexConfig::Int)]),
+        };
+
+        let collection = Collection::init(
+            collection_name,
+            config,
+            path,
+            Arc::new(ChannelService::empty(100)),
+        )
+        .await
+        .expect("Failed to initialize collection");
+
+        let points = vec![
+            Point {
+                id: PointId::Id(1),
+                payload: json!({"field1": "value1", "age": 10}),
+            },
+            Point {
+                id: PointId::Id(2),
+                payload: json!({"field1": "value2", "age": 20}),
+            },
+            Point {
+                id: PointId::Id(3),
+                payload: json!({"field1": "value3", "age": 30}),
+            },
+        ];
+
+        collection
+            .upsert_points(points.clone(), false)
+            .await
+            .expect("Failed to upsert points");
+
+        let read_all_points = collection
+            .read_points(None, None, false)
+            .await
+            .expect("Failed to read all points");
+
+        assert_eq!(read_all_points, points);
+
+        let read_points = collection
+            .read_points(Some(vec![PointId::Id(1)]), None, false)
+            .await
+            .expect("Failed to read points");
+
+        assert_eq!(read_points.len(), 1);
+        assert_eq!(read_points[0], points[0]);
+
+        let query = Query {
+            filter: QueryFilter::new("age", "25", FilterOperator::Gte),
+        };
+
+        let queried_points = collection
+            .query_points(query)
+            .await
+            .expect("Failed to query points");
+
+        assert_eq!(queried_points.len(), 1);
+        assert_eq!(queried_points[0], points[2]);
+    }
+}

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -428,9 +428,7 @@ mod tests {
             payload_schema: BTreeMap::new(),
         };
 
-        config
-            .save(&path)
-            .expect("Failed to save collection config");
+        config.save(path).expect("Failed to save collection config");
 
         let config_path = path.join(COLLECTION_CONFIG_FILE);
         assert!(config_path.exists());
@@ -456,13 +454,11 @@ mod tests {
             ]),
         };
 
-        config
-            .save(&path)
-            .expect("Failed to save collection config");
+        config.save(path).expect("Failed to save collection config");
 
         let collection = Collection::load(
             collection_name.clone(),
-            &path,
+            path,
             Arc::new(ChannelService::empty(100)),
         )
         .expect("Failed to load collection");

--- a/src/storage/index/filter.rs
+++ b/src/storage/index/filter.rs
@@ -16,3 +16,13 @@ pub struct QueryFilter {
     pub value: String,
     pub op: FilterOperator,
 }
+
+impl QueryFilter {
+    pub fn new(key: impl Into<String>, value: impl Into<String>, op: FilterOperator) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+            op,
+        }
+    }
+}

--- a/src/storage/index/payload_index.rs
+++ b/src/storage/index/payload_index.rs
@@ -104,7 +104,7 @@ pub enum FieldIndex {
     Null,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum IndexConfig {
     Int,
@@ -227,18 +227,23 @@ impl PayloadIndex {
 
     pub fn query(&self, query: Query) -> Result<Vec<PointId>, sled::Error> {
         let mut results = HashSet::new();
-        for (index_name, index) in &self.indices {
-            if *index_name == query.filter.key {
-                match index {
-                    FieldIndex::Int(int_index) => {
-                        let value = query.filter.value.parse::<i64>().unwrap();
-                        let query_results = int_index.query(value, &query.filter.op)?;
-                        results.extend(query_results);
-                    }
-                    FieldIndex::Null => {
-                        unimplemented!("Null index queries are not implemented yet");
-                    }
-                }
+
+        // ToDo: Should allow querying for un-indexed fields to demonstrate/benchmark difference
+        let index = self.indices.get(&query.filter.key).ok_or_else(|| {
+            sled::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("No index found for key '{}'", query.filter.key),
+            ))
+        })?;
+
+        match index {
+            FieldIndex::Int(int_index) => {
+                let value = query.filter.value.parse::<i64>().unwrap();
+                let query_results = int_index.query(value, &query.filter.op)?;
+                results.extend(query_results);
+            }
+            FieldIndex::Null => {
+                unimplemented!("Null index queries are not implemented yet");
             }
         }
         Ok(results.into_iter().collect())

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -25,7 +25,7 @@ impl PointId {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Point {
     pub id: PointId,
     pub payload: serde_json::Value,

--- a/src/storage/toc.rs
+++ b/src/storage/toc.rs
@@ -13,6 +13,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::RwLock;
+use tokio::sync::RwLockReadGuard;
 
 pub const COLLECTIONS_DIR: &str = "collections";
 
@@ -148,23 +149,37 @@ impl TableOfContent {
         }
     }
 
+    async fn get_collection(
+        &self,
+        collection_name: &str,
+    ) -> Result<RwLockReadGuard<Collection>, StorageError> {
+        let collections = self.collections.read().await;
+
+        if !collections.contains_key(collection_name) {
+            return Err(StorageError::BadInput(format!(
+                "Collection '{collection_name}' does not exist"
+            )));
+        }
+
+        let collection_guard = RwLockReadGuard::map(collections, |collections| {
+            collections.get(collection_name).unwrap() // safe since we checked the key exists
+        });
+
+        Ok(collection_guard)
+    }
+
     pub async fn upsert_points(
         &self,
         collection_name: &str,
         points: Vec<Point>,
     ) -> Result<(), StorageError> {
-        let collections = self.collections.read().await;
-        let collection = collections.get(collection_name).ok_or_else(|| {
-            StorageError::BadInput(format!("Collection '{collection_name}' does not exist"))
-        })?;
+        let collection = self.get_collection(collection_name).await?;
 
         collection.upsert_points(points, false).await.map_err(|e| {
             StorageError::ServiceError(format!(
                 "Failed to upsert points in collection '{collection_name}': {e}"
             ))
-        })?;
-
-        Ok(())
+        })
     }
 
     pub async fn read_points(
@@ -172,10 +187,7 @@ impl TableOfContent {
         collection_name: &str,
         ids: Option<Vec<PointId>>,
     ) -> Result<Vec<Point>, StorageError> {
-        let collections = self.collections.read().await;
-        let collection = collections.get(collection_name).ok_or_else(|| {
-            StorageError::BadInput(format!("Collection '{collection_name}' does not exist"))
-        })?;
+        let collection = self.get_collection(collection_name).await?;
 
         collection.read_points(ids, None, false).await.map_err(|e| {
             StorageError::ServiceError(format!(
@@ -189,10 +201,7 @@ impl TableOfContent {
         collection_name: &str,
         query: Query,
     ) -> Result<Vec<Point>, StorageError> {
-        let collections = self.collections.read().await;
-        let collection = collections.get(collection_name).ok_or_else(|| {
-            StorageError::BadInput(format!("Collection '{collection_name}' does not exist"))
-        })?;
+        let collection = self.get_collection(collection_name).await?;
 
         collection.query_points(query).await.map_err(|e| {
             StorageError::ServiceError(format!(

--- a/src/storage/toc.rs
+++ b/src/storage/toc.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::points::{PointsOperation, Query},
+    api::points::Query,
     channel_service::ChannelService,
     error::StorageError,
     storage::{
@@ -148,31 +148,23 @@ impl TableOfContent {
         }
     }
 
-    pub async fn perform_points_op(
+    pub async fn upsert_points(
         &self,
         collection_name: &str,
-        operation: PointsOperation,
-    ) -> Result<bool, StorageError> {
-        // ToDo: Have independent read locks for each collection. It should improve perf?
+        points: Vec<Point>,
+    ) -> Result<(), StorageError> {
         let collections = self.collections.read().await;
         let collection = collections.get(collection_name).ok_or_else(|| {
             StorageError::BadInput(format!("Collection '{collection_name}' does not exist"))
         })?;
 
-        match operation {
-            PointsOperation::Upsert(upsert_points) => {
-                collection
-                    .upsert_points(upsert_points.points, false)
-                    .await
-                    .map_err(|e| {
-                        StorageError::ServiceError(format!(
-                            "Failed to upsert points in collection '{collection_name}': {e}"
-                        ))
-                    })?;
-            }
-        }
+        collection.upsert_points(points, false).await.map_err(|e| {
+            StorageError::ServiceError(format!(
+                "Failed to upsert points in collection '{collection_name}': {e}"
+            ))
+        })?;
 
-        Ok(true)
+        Ok(())
     }
 
     pub async fn read_points(


### PR DESCRIPTION
- Make all the APIs consistent and clean
- Use tokio::sync::RwLockReadGuard::map
- Add tests for collections
- Reject filter queries on un-indexed fields