### PR TITLE
Extend query API to query the cluster instead of local shards

### DIFF
--- a/src/api/grpc/conversion.rs
+++ b/src/api/grpc/conversion.rs
@@ -1,0 +1,31 @@
+use crate::api::grpc::schema::QueryPointsParams as GrpcQueryPointsParams;
+use crate::api::points::Query;
+use crate::storage::index::filter::QueryFilter;
+
+impl Query {
+    pub fn from_grpc(query: Option<GrpcQueryPointsParams>) -> Result<Self, String> {
+        let query = query.ok_or_else(|| "Query parameters are required".to_string())?;
+
+        let filter = query
+            .filter
+            .ok_or_else(|| "Query filter is required".to_string())?;
+
+        Ok(Self {
+            filter: QueryFilter {
+                key: filter.key,
+                value: filter.value,
+                op: filter.op.into(),
+            },
+        })
+    }
+
+    pub fn into_grpc(self) -> Option<GrpcQueryPointsParams> {
+        Some(GrpcQueryPointsParams {
+            filter: Some(crate::api::grpc::schema::QueryFilter {
+                key: self.filter.key,
+                value: self.filter.value,
+                op: self.filter.op.as_str().to_string(),
+            }),
+        })
+    }
+}

--- a/src/api/grpc/mod.rs
+++ b/src/api/grpc/mod.rs
@@ -1,6 +1,7 @@
 #[rustfmt::skip] // tonic uses `prettyplease` to format its output
 pub mod schema;
 
+mod conversion;
 mod points_service;
 mod raft_service;
 mod simple_service;

--- a/src/api/grpc/points_service.rs
+++ b/src/api/grpc/points_service.rs
@@ -1,8 +1,11 @@
 use crate::{
-    api::grpc::schema::{
-        points_internal_server::PointsInternal, GetPointsRequest, GetPointsResponse,
-        Point as GrpcPoint, QueryPointsRequest, QueryPointsResponse, UpsertPointsRequest,
-        UpsertPointsResponse,
+    api::{
+        grpc::schema::{
+            points_internal_server::PointsInternal, GetPointsRequest, GetPointsResponse,
+            Point as GrpcPoint, QueryPointsRequest, QueryPointsResponse, UpsertPointsRequest,
+            UpsertPointsResponse,
+        },
+        points::Query,
     },
     storage::{
         segment::{Point, PointId},
@@ -76,32 +79,63 @@ impl PointsInternal for PointsInternalService {
         &self,
         request: tonic::Request<QueryPointsRequest>,
     ) -> Result<Response<QueryPointsResponse>, tonic::Status> {
-        let _query = request.into_inner();
-        // Assuming Query has a filter field, which is not defined in the original code
-        // let filter = _query.filter;
+        let QueryPointsRequest {
+            collection_name,
+            query,
+        } = request.into_inner();
 
         println!("Received internal request to query points");
 
+        let query = Query::from_grpc(query)
+            .map_err(|e| tonic::Status::invalid_argument(format!("Invalid query: {e}")))?;
+
+        let collection = self
+            .toc
+            .get_collection(&collection_name)
+            .await
+            .map_err(|e| {
+                tonic::Status::not_found(format!("Collection '{collection_name}' not found: {e}"))
+            })?;
+
+        let points = collection.query_points(query, true).await.map_err(|e| {
+            tonic::Status::internal(format!(
+                "Failed to query points in collection '{collection_name}': {e}"
+            ))
+        })?;
+
         Ok(Response::new(QueryPointsResponse {
-            points: vec![], // ToDo: Implement actual query logic
+            points: points
+                .into_iter()
+                .filter_map(|p| {
+                    if let PointId::Id(id) = p.id {
+                        // FixMe: This is a workaround for not being able to pass json just yet.
+                        let payload = p.payload.to_string();
+                        return Some(GrpcPoint { id, payload });
+                    }
+                    None // ignore UUIDs for now
+                })
+                .collect(),
         }))
     }
 
     async fn upsert_points(
         &self,
-        _request: tonic::Request<UpsertPointsRequest>,
+        request: tonic::Request<UpsertPointsRequest>,
     ) -> Result<Response<UpsertPointsResponse>, tonic::Status> {
         let UpsertPointsRequest {
             collection_name,
             points,
             shard_id: _, // ToDo: We should specify shard_id when upserting?
-        } = _request.into_inner();
+        } = request.into_inner();
         debug!("Received internal request to upsert points from collection: {collection_name}");
 
-        let collections = self.toc.collections.read().await;
-        let collection = collections.get(&collection_name).ok_or_else(|| {
-            tonic::Status::not_found(format!("Collection '{collection_name}' not found"))
-        })?;
+        let collection = self
+            .toc
+            .get_collection(&collection_name)
+            .await
+            .map_err(|e| {
+                tonic::Status::not_found(format!("Collection '{collection_name}' not found: {e}"))
+            })?;
 
         let points = points
             .into_iter()

--- a/src/api/grpc/points_service.rs
+++ b/src/api/grpc/points_service.rs
@@ -1,7 +1,8 @@
 use crate::{
     api::grpc::schema::{
         points_internal_server::PointsInternal, GetPointsRequest, GetPointsResponse,
-        Point as GrpcPoint, UpsertPointsRequest, UpsertPointsResponse,
+        Point as GrpcPoint, QueryPointsRequest, QueryPointsResponse, UpsertPointsRequest,
+        UpsertPointsResponse,
     },
     storage::{
         segment::{Point, PointId},
@@ -68,6 +69,21 @@ impl PointsInternal for PointsInternalService {
                     None // ignore UUIDs for now
                 })
                 .collect(),
+        }))
+    }
+
+    async fn query_points(
+        &self,
+        request: tonic::Request<QueryPointsRequest>,
+    ) -> Result<Response<QueryPointsResponse>, tonic::Status> {
+        let _query = request.into_inner();
+        // Assuming Query has a filter field, which is not defined in the original code
+        // let filter = _query.filter;
+
+        println!("Received internal request to query points");
+
+        Ok(Response::new(QueryPointsResponse {
+            points: vec![], // ToDo: Implement actual query logic
         }))
     }
 

--- a/src/api/grpc/proto/smoldb.proto
+++ b/src/api/grpc/proto/smoldb.proto
@@ -64,8 +64,9 @@ message Uri {
 // Internal points service for syncing data between peers:
 
 service PointsInternal {
-  rpc GetPoints (GetPointsRequest) returns (GetPointsResponse) {}
   rpc UpsertPoints (UpsertPointsRequest) returns (UpsertPointsResponse) {}
+  rpc GetPoints (GetPointsRequest) returns (GetPointsResponse) {}
+  rpc QueryPoints (QueryPointsRequest) returns (QueryPointsResponse) {}
 }
 
 message UpsertPointsRequest {
@@ -87,6 +88,14 @@ message GetPointsRequest {
   repeated uint64 ids = 2;
   bool return_all = 3; // If true, return all points in the collection
   optional uint32 shard_id = 4;
+}
+
+message QueryPointsRequest {
+  string collection_name = 1;
+}
+
+message QueryPointsResponse {
+  repeated Point points = 1;
 }
 
 message Point {

--- a/src/api/grpc/proto/smoldb.proto
+++ b/src/api/grpc/proto/smoldb.proto
@@ -90,8 +90,19 @@ message GetPointsRequest {
   optional uint32 shard_id = 4;
 }
 
+message QueryFilter {
+  string key = 1;
+  string value = 2;
+  string op = 3;
+}
+
+message QueryPointsParams {
+  QueryFilter filter = 1;
+}
+
 message QueryPointsRequest {
   string collection_name = 1;
+  QueryPointsParams query = 2;
 }
 
 message QueryPointsResponse {

--- a/src/api/grpc/schema.rs
+++ b/src/api/grpc/schema.rs
@@ -78,6 +78,16 @@ pub struct GetPointsRequest {
     pub shard_id: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryPointsRequest {
+    #[prost(string, tag = "1")]
+    pub collection_name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryPointsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub points: ::prost::alloc::vec::Vec<Point>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Point {
     #[prost(uint64, tag = "1")]
     pub id: u64,
@@ -444,6 +454,30 @@ pub mod points_internal_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
+        pub async fn upsert_points(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpsertPointsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::UpsertPointsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/smoldb.PointsInternal/UpsertPoints",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("smoldb.PointsInternal", "UpsertPoints"));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn get_points(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPointsRequest>,
@@ -468,11 +502,11 @@ pub mod points_internal_client {
                 .insert(GrpcMethod::new("smoldb.PointsInternal", "GetPoints"));
             self.inner.unary(req, path, codec).await
         }
-        pub async fn upsert_points(
+        pub async fn query_points(
             &mut self,
-            request: impl tonic::IntoRequest<super::UpsertPointsRequest>,
+            request: impl tonic::IntoRequest<super::QueryPointsRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::UpsertPointsResponse>,
+            tonic::Response<super::QueryPointsResponse>,
             tonic::Status,
         > {
             self.inner
@@ -485,11 +519,11 @@ pub mod points_internal_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/smoldb.PointsInternal/UpsertPoints",
+                "/smoldb.PointsInternal/QueryPoints",
             );
             let mut req = request.into_request();
             req.extensions_mut()
-                .insert(GrpcMethod::new("smoldb.PointsInternal", "UpsertPoints"));
+                .insert(GrpcMethod::new("smoldb.PointsInternal", "QueryPoints"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -964,6 +998,13 @@ pub mod points_internal_server {
     /// Generated trait containing gRPC methods that should be implemented for use with PointsInternalServer.
     #[async_trait]
     pub trait PointsInternal: std::marker::Send + std::marker::Sync + 'static {
+        async fn upsert_points(
+            &self,
+            request: tonic::Request<super::UpsertPointsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::UpsertPointsResponse>,
+            tonic::Status,
+        >;
         async fn get_points(
             &self,
             request: tonic::Request<super::GetPointsRequest>,
@@ -971,11 +1012,11 @@ pub mod points_internal_server {
             tonic::Response<super::GetPointsResponse>,
             tonic::Status,
         >;
-        async fn upsert_points(
+        async fn query_points(
             &self,
-            request: tonic::Request<super::UpsertPointsRequest>,
+            request: tonic::Request<super::QueryPointsRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::UpsertPointsResponse>,
+            tonic::Response<super::QueryPointsResponse>,
             tonic::Status,
         >;
     }
@@ -1055,6 +1096,51 @@ pub mod points_internal_server {
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             match req.uri().path() {
+                "/smoldb.PointsInternal/UpsertPoints" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpsertPointsSvc<T: PointsInternal>(pub Arc<T>);
+                    impl<
+                        T: PointsInternal,
+                    > tonic::server::UnaryService<super::UpsertPointsRequest>
+                    for UpsertPointsSvc<T> {
+                        type Response = super::UpsertPointsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UpsertPointsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as PointsInternal>::upsert_points(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = UpsertPointsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/smoldb.PointsInternal/GetPoints" => {
                     #[allow(non_camel_case_types)]
                     struct GetPointsSvc<T: PointsInternal>(pub Arc<T>);
@@ -1100,25 +1186,25 @@ pub mod points_internal_server {
                     };
                     Box::pin(fut)
                 }
-                "/smoldb.PointsInternal/UpsertPoints" => {
+                "/smoldb.PointsInternal/QueryPoints" => {
                     #[allow(non_camel_case_types)]
-                    struct UpsertPointsSvc<T: PointsInternal>(pub Arc<T>);
+                    struct QueryPointsSvc<T: PointsInternal>(pub Arc<T>);
                     impl<
                         T: PointsInternal,
-                    > tonic::server::UnaryService<super::UpsertPointsRequest>
-                    for UpsertPointsSvc<T> {
-                        type Response = super::UpsertPointsResponse;
+                    > tonic::server::UnaryService<super::QueryPointsRequest>
+                    for QueryPointsSvc<T> {
+                        type Response = super::QueryPointsResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::UpsertPointsRequest>,
+                            request: tonic::Request<super::QueryPointsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as PointsInternal>::upsert_points(&inner, request).await
+                                <T as PointsInternal>::query_points(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1129,7 +1215,7 @@ pub mod points_internal_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = UpsertPointsSvc(inner);
+                        let method = QueryPointsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/src/api/grpc/schema.rs
+++ b/src/api/grpc/schema.rs
@@ -78,9 +78,25 @@ pub struct GetPointsRequest {
     pub shard_id: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryFilter {
+    #[prost(string, tag = "1")]
+    pub key: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub value: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub op: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryPointsParams {
+    #[prost(message, optional, tag = "1")]
+    pub filter: ::core::option::Option<QueryFilter>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryPointsRequest {
     #[prost(string, tag = "1")]
     pub collection_name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub query: ::core::option::Option<QueryPointsParams>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryPointsResponse {

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -4,9 +4,7 @@ use crate::{
     error::{CollectionError, CollectionResult, StorageError},
     storage::{
         index::payload_index::IndexConfig,
-        replicas::{
-            local_shard::LocalShard, ReplicaHolder, ReplicaSet, ShardOperationTrait, ShardState,
-        },
+        replicas::{local_shard::LocalShard, ReplicaHolder, ReplicaSet, ShardState},
         segment::{Point, PointId},
     },
     types::{PeerId, ShardId},
@@ -43,8 +41,6 @@ impl Collection {
         path: &Path,
         channel_service: Arc<ChannelService>,
     ) -> Result<Self, StorageError> {
-        // ToDo: Create ShardHolder & ShardReplicaSet
-
         config.save(path)?;
 
         // ToDo: Initialize shards == num_cpus for max parallelism
@@ -167,26 +163,18 @@ impl Collection {
     ) -> CollectionResult<()> {
         let replica_holder_guard = self.replica_holder.read().await;
 
-        let point_ids: Vec<_> = points.iter().map(|point| point.id.clone()).collect();
-
-        let points_map: HashMap<PointId, Point> = points
-            .into_iter()
-            .map(|point| (point.id.clone(), point))
-            .collect();
-
         let mut replicas_to_mark_dead = vec![];
 
         // ToDo: Run this operation concurrently for each shard
-        for (shard_id, shard_point_ids) in replica_holder_guard.select_shards(&point_ids)? {
+        for (shard_id, points) in replica_holder_guard.group_by_shards(Some(points))? {
+            let Some(points) = points else {
+                continue; // No points for this shard
+            };
+
             let replica_set = replica_holder_guard
                 .shards
                 .get(&shard_id)
                 .ok_or_else(|| StorageError::BadInput(format!("Shard {shard_id} not found")))?;
-
-            let points = shard_point_ids
-                .iter()
-                .filter_map(|id| points_map.get(id).cloned())
-                .collect::<Vec<_>>();
 
             let results = replica_set
                 .execute_cluster_operation(
@@ -256,69 +244,76 @@ impl Collection {
         local_only: bool,
     ) -> CollectionResult<Vec<Point>> {
         let replica_holder = self.replica_holder.read().await;
+        let mut shard_id_to_point = replica_holder.group_by_shards(ids)?;
 
-        let Some(ids) = ids else {
-            // If no ids are provided, return all points from all shards
-            let mut all_points = BTreeMap::new();
-            for (current_shard_id, replica_set) in replica_holder.shards.iter() {
-                if let Some(desired_shard) = shard_id {
-                    if *current_shard_id != desired_shard {
-                        continue; // Skip shards that are not the desired shard
-                    }
-                }
-
-                let replica_results = replica_set
-                    .execute_cluster_operation(
-                        |shard| {
-                            let ids_cloned = ids.clone();
-                            async move { shard.get_points(ids_cloned).await }.boxed()
-                        },
-                        local_only,
-                    )
-                    .await
-                    .into_iter()
-                    .map(|(_peer_id, r)| r)
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                for point in replica_results.into_iter().flatten() {
-                    // We only insert if the point is not already present so that local shard takes precedence
-                    if let Entry::Vacant(e) = all_points.entry(point.id.clone()) {
-                        e.insert(point);
-                    }
-                }
-            }
-            return Ok(all_points.into_values().collect());
-        };
-
+        // If a shard id is provided, only query that particular shard
         if let Some(shard_id) = shard_id {
-            let replica_set = replica_holder.get_replica_set(shard_id).await?;
-            Ok(replica_set.local.get_points(Some(ids)).await?)
-        } else {
-            let mut points = vec![];
-
-            for (shard_id, shard_point_ids) in replica_holder.select_shards(&ids)? {
-                let replica_set = replica_holder.get_replica_set(shard_id).await?;
-
-                let collected_points = replica_set.local.get_points(Some(shard_point_ids)).await?;
-                points.extend(collected_points);
-            }
-
-            Ok(points)
+            shard_id_to_point.retain(|&id, _| id == shard_id);
         }
+
+        let mut all_points = BTreeMap::new();
+
+        for (shard_id, shard_point_ids) in shard_id_to_point {
+            let replica_set = replica_holder.get_replica_set(shard_id).await?;
+
+            let replica_results = replica_set
+                .execute_cluster_operation(
+                    |shard| {
+                        let ids_cloned = shard_point_ids.clone();
+                        async move { shard.get_points(ids_cloned).await }.boxed()
+                    },
+                    local_only,
+                )
+                .await
+                .into_iter()
+                .map(|(_peer_id, r)| r)
+                .collect::<Result<Vec<_>, _>>()?;
+
+            for point in replica_results.into_iter().flatten() {
+                // Insert if the point is not already present so that local shard takes precedence in case of conflicts
+                if let Entry::Vacant(e) = all_points.entry(point.id.clone()) {
+                    e.insert(point);
+                }
+            }
+        }
+
+        Ok(all_points.into_values().collect())
     }
 
-    pub async fn query_points(&self, query: Query) -> CollectionResult<Vec<Point>> {
+    pub async fn query_points(
+        &self,
+        query: Query,
+        local_only: bool,
+    ) -> CollectionResult<Vec<Point>> {
         let replica_holder = self.replica_holder.read().await;
+        let all_shards = replica_holder.group_by_shards::<PointId>(None)?; // query all shards
+        let mut all_points = BTreeMap::new();
 
-        let mut results = vec![];
-        for (_shard_id, replica_set) in replica_holder.shards.iter() {
-            let shard_results = replica_set.local.query_points(query.clone()).await?;
-            results.extend(shard_results);
+        for (shard_id, _query_all) in all_shards {
+            let replica_set = replica_holder.get_replica_set(shard_id).await?;
+
+            let replica_results = replica_set
+                .execute_cluster_operation(
+                    |shard| {
+                        let query_cloned = query.clone();
+                        async move { shard.query_points(query_cloned).await }.boxed()
+                    },
+                    local_only,
+                )
+                .await
+                .into_iter()
+                .map(|(_peer_id, r)| r)
+                .collect::<Result<Vec<_>, _>>()?;
+
+            for point in replica_results.into_iter().flatten() {
+                // Insert if the point is not already present so that local shard takes precedence in case of conflicts
+                if let Entry::Vacant(e) = all_points.entry(point.id.clone()) {
+                    e.insert(point);
+                }
+            }
         }
 
-        // ToDo: Implement cluster level query
-
-        Ok(results)
+        Ok(all_points.into_values().collect())
     }
 }
 
@@ -528,7 +523,7 @@ mod tests {
         };
 
         let queried_points = collection
-            .query_points(query)
+            .query_points(query, false)
             .await
             .expect("Failed to query points");
 

--- a/src/storage/index/filter.rs
+++ b/src/storage/index/filter.rs
@@ -10,6 +10,31 @@ pub enum FilterOperator {
     Lt,
 }
 
+impl FilterOperator {
+    pub fn as_str(&self) -> &str {
+        match self {
+            FilterOperator::Gte => "gte",
+            FilterOperator::Eq => "eq",
+            FilterOperator::Lte => "lte",
+            FilterOperator::Gt => "gt",
+            FilterOperator::Lt => "lt",
+        }
+    }
+}
+
+impl From<String> for FilterOperator {
+    fn from(op: String) -> Self {
+        match op.as_str() {
+            "gte" => FilterOperator::Gte,
+            "eq" => FilterOperator::Eq,
+            "lte" => FilterOperator::Lte,
+            "gt" => FilterOperator::Gt,
+            "lt" => FilterOperator::Lt,
+            _ => panic!("Unknown filter operator: {op}"),
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct QueryFilter {
     pub key: String,

--- a/src/storage/replicas/mod.rs
+++ b/src/storage/replicas/mod.rs
@@ -13,6 +13,7 @@ use log::{error, warn};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::vec;
 use tonic::async_trait;
 
 #[derive(Copy, Clone, Debug)]
@@ -127,6 +128,22 @@ impl ReplicaSet {
     }
 }
 
+pub trait HasPointId {
+    fn point_id(&self) -> PointId;
+}
+
+impl HasPointId for Point {
+    fn point_id(&self) -> PointId {
+        self.id.clone()
+    }
+}
+
+impl HasPointId for PointId {
+    fn point_id(&self) -> PointId {
+        self.clone()
+    }
+}
+
 pub struct ReplicaHolder {
     pub shards: HashMap<ShardId, ReplicaSet>,
     ring: hashring::HashRing<(ShardId, usize)>,
@@ -201,23 +218,41 @@ impl ReplicaHolder {
         Ok(())
     }
 
-    pub fn select_shards(
+    /// Find shards that are expected to hold the points based on the hash ring.
+    ///
+    /// If returned `point_ids` is `None`, it means the caller should read/write all shards.
+    /// If `point_ids` is `Some`, it contains the point IDs that should be routed to the respective shards.
+    pub fn group_by_shards<T: HasPointId>(
         &self,
-        point_ids: &[PointId],
-    ) -> Result<HashMap<ShardId, Vec<PointId>>, StorageError> {
+        points: Option<Vec<T>>,
+    ) -> Result<HashMap<ShardId, Option<Vec<T>>>, StorageError> {
+        let Some(points) = points else {
+            // If no point IDs are provided, return all shards with None
+            return Ok(self
+                .shards
+                .keys()
+                .map(|&shard_id| (shard_id, None))
+                .collect());
+        };
+
         let mut shards_to_point_ids = HashMap::new();
-        for point_id in point_ids {
-            let (shard_id, _virtual_shard_idx) = self
-                .ring
-                .get(&point_id)
-                .ok_or_else(|| StorageError::ServiceError("No shards found".to_string()))?;
+
+        for point in points {
+            let point_id = point.point_id();
+            let (shard_id, _virtual_shard_idx) = self.ring.get(&point_id).ok_or_else(|| {
+                StorageError::ServiceError("No shards found in hashring".to_string())
+            })?;
 
             shards_to_point_ids
                 .entry(*shard_id)
                 .or_insert_with(Vec::new)
-                .push(point_id.clone());
+                .push(point);
         }
-        Ok(shards_to_point_ids)
+
+        Ok(shards_to_point_ids
+            .into_iter()
+            .map(|(shard_id, ids)| (shard_id, Some(ids)))
+            .collect())
     }
 }
 
@@ -241,20 +276,23 @@ mod tests {
         ]));
 
         let shards_to_point_ids = shard_holder
-            .select_shards(&[
+            .group_by_shards(Some(vec![
                 PointId::Id(1),
                 PointId::Id(2),
                 PointId::Id(100),
                 PointId::Uuid("dummy-uuid".to_string()),
-            ])
+            ]))
             .unwrap();
 
         let expected_grouping = HashMap::from_iter([
             (
                 0,
-                vec![PointId::Id(100), PointId::Uuid("dummy-uuid".to_string())],
+                Some(vec![
+                    PointId::Id(100),
+                    PointId::Uuid("dummy-uuid".to_string()),
+                ]),
             ),
-            (1, vec![PointId::Id(1), PointId::Id(2)]),
+            (1, Some(vec![PointId::Id(1), PointId::Id(2)])),
         ]);
 
         assert_eq!(shards_to_point_ids, expected_grouping);

--- a/src/storage/replicas/remote_shard.rs
+++ b/src/storage/replicas/remote_shard.rs
@@ -2,7 +2,7 @@ use crate::{
     api::{
         grpc::schema::{
             points_internal_client::PointsInternalClient, GetPointsRequest, Point as PointGrpc,
-            UpsertPointsRequest,
+            QueryPointsRequest, UpsertPointsRequest,
         },
         points::Query,
     },
@@ -145,9 +145,31 @@ impl ShardOperationTrait for RemoteShard {
     }
 
     async fn query_points(&self, _query: Query) -> CollectionResult<Vec<Point>> {
-        // Remote shard does not support querying yet
-        Err(CollectionError::ServiceError(
-            "Remote shard does not support querying points".to_string(),
-        ))
+        let query_response = self
+            .with_points_client(|mut client| {
+                async move {
+                    // Placeholder for actual query logic
+                    // This should be replaced with the actual query implementation
+                    client
+                        .query_points(Request::new(QueryPointsRequest {
+                            collection_name: self.collection.clone(),
+                            // filter: _query.filter, // Assuming Query has a filter field
+                        }))
+                        .await
+                }
+            })
+            .await?
+            .into_inner();
+
+        let points = query_response
+            .points
+            .into_iter()
+            .map(|p| Point {
+                id: PointId::Id(p.id),
+                payload: serde_json::from_str(&p.payload).unwrap(),
+            })
+            .collect::<Vec<_>>();
+
+        Ok(points)
     }
 }

--- a/src/storage/replicas/remote_shard.rs
+++ b/src/storage/replicas/remote_shard.rs
@@ -144,16 +144,17 @@ impl ShardOperationTrait for RemoteShard {
         Ok(()) // Placeholder for actual remote shard logic
     }
 
-    async fn query_points(&self, _query: Query) -> CollectionResult<Vec<Point>> {
+    async fn query_points(&self, query: Query) -> CollectionResult<Vec<Point>> {
         let query_response = self
             .with_points_client(|mut client| {
+                let query = query.clone().into_grpc();
                 async move {
                     // Placeholder for actual query logic
                     // This should be replaced with the actual query implementation
                     client
                         .query_points(Request::new(QueryPointsRequest {
                             collection_name: self.collection.clone(),
-                            // filter: _query.filter, // Assuming Query has a filter field
+                            query,
                         }))
                         .await
                 }

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -8,7 +8,6 @@ use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
 };
-
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Debug)]
 #[serde(untagged)]
 pub enum PointId {

--- a/src/storage/toc.rs
+++ b/src/storage/toc.rs
@@ -203,7 +203,7 @@ impl TableOfContent {
     ) -> Result<Vec<Point>, StorageError> {
         let collection = self.get_collection(collection_name).await?;
 
-        collection.query_points(query).await.map_err(|e| {
+        collection.query_points(query, false).await.map_err(|e| {
             StorageError::ServiceError(format!(
                 "Failed to query points in collection '{collection_name}': {e}"
             ))

--- a/src/storage/toc.rs
+++ b/src/storage/toc.rs
@@ -149,7 +149,7 @@ impl TableOfContent {
         }
     }
 
-    async fn get_collection(
+    pub async fn get_collection(
         &self,
         collection_name: &str,
     ) -> Result<RwLockReadGuard<Collection>, StorageError> {


### PR DESCRIPTION
Also simplifies the existing logic by introducing

```rs
pub fn group_by_shards<T: HasPointId>(
        &self,
        points: Option<Vec<T>>,
    ) -> Result<HashMap<ShardId, Option<Vec<T>>>, StorageError> {
   // ...    
}
```