### PR TITLE
Make payload schema optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,33 @@ curl -X PUT http://localhost:9000/collections/test \
 curl -X PUT http://localhost:9000/collections/test/points \
   -H "Content-Type: application/json" \
   -d '{
-    "points": [ { "id": 0, "payload": { "msg": "hello world" } } ]
+    "points": [
+        { "id": 0, "payload": { "msg": "hello world" } },
+        { "id": 10, "payload": { "msg": "foo bar" } },
+        { "id": 123, "payload": { "msg": "bar baz" } }
+     ]
   }'
 
-# Get point (response below)
-curl -X GET http://localhost:9000/collections/test/points/0
+# Get all points (response below)
+curl -X GET http://localhost:9000/collections/test/points
 
-# Response:
 {
-  "id": 0,
-  "payload": {
-    "msg": "hello world"
-  }
+    "result": {
+        "points": [
+            {
+                "id": 0,
+                "payload": {
+                    "msg": "hello world"
+                }
+            },
+            # ...
+        ]
+    },
+    "time": 0.000211024
 }
+
+# Get specific point
+curl -X GET http://localhost:9000/collections/test/points/0
 
 # Get collection's cluster info (response below)
 curl -X GET http://localhost:9000/collections/test/cluster
@@ -48,12 +62,12 @@ curl -X GET http://localhost:9000/collections/test/cluster
     "local_shards": [
         {
             "shard_id": 1,
-            "point_count": 0,
+            "point_count": 1,
             "state": "Active"
         },
         {
             "shard_id": 0,
-            "point_count": 1,
+            "point_count": 2,
             "state": "Active"
         }
     ],

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -386,7 +386,7 @@ mod tests {
         let collection_name = "test_collection".to_string();
         let config = CollectionConfig {
             params: "test_params".to_string(),
-            payload_schema: BTreeMap::new(),
+            payload_schema: None,
         };
 
         let collection = Collection::init(
@@ -421,7 +421,7 @@ mod tests {
         let path = temp_dir.path();
         let config = CollectionConfig {
             params: "test_params".to_string(),
-            payload_schema: BTreeMap::new(),
+            payload_schema: None,
         };
 
         config.save(path).expect("Failed to save collection config");
@@ -444,10 +444,10 @@ mod tests {
         let collection_name = "test_collection".to_string();
         let config = CollectionConfig {
             params: "test_params".to_string(),
-            payload_schema: BTreeMap::from_iter([
+            payload_schema: Some(BTreeMap::from_iter([
                 ("field1".to_string(), IndexConfig::Int),
                 ("field2".to_string(), IndexConfig::Null),
-            ]),
+            ])),
         };
 
         config.save(path).expect("Failed to save collection config");
@@ -472,7 +472,7 @@ mod tests {
 
         let config = CollectionConfig {
             params: "test_params".to_string(),
-            payload_schema: BTreeMap::from_iter([("age".to_string(), IndexConfig::Int)]),
+            payload_schema: Some(BTreeMap::from_iter([("age".to_string(), IndexConfig::Int)])),
         };
 
         let collection = Collection::init(

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -54,7 +54,7 @@ impl Collection {
                 let shard_id = shard_id as ShardId;
                 // No remote replicas initially. They will be added by Collection::add_remote_replicas
                 let replica_set = ReplicaSet::new(
-                    LocalShard::init(shard_path, shard_id, Some(config.payload_schema.clone())),
+                    LocalShard::init(shard_path, shard_id, config.payload_schema.clone()),
                     id.clone(),
                     shard_id,
                     channel_service.clone(),
@@ -320,7 +320,8 @@ impl Collection {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CollectionConfig {
     pub params: String,
-    pub payload_schema: BTreeMap<String, IndexConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_schema: Option<BTreeMap<String, IndexConfig>>,
 }
 
 impl CollectionConfig {

--- a/src/storage/toc.rs
+++ b/src/storage/toc.rs
@@ -152,7 +152,7 @@ impl TableOfContent {
     pub async fn get_collection(
         &self,
         collection_name: &str,
-    ) -> Result<RwLockReadGuard<Collection>, StorageError> {
+    ) -> Result<RwLockReadGuard<'_, Collection>, StorageError> {
         let collections = self.collections.read().await;
 
         if !collections.contains_key(collection_name) {


### PR DESCRIPTION
```bash
# This should be sufficient to create collection
curl -X PUT http://localhost:9000/collections/test \
  -H "Content-Type: application/json" \
  -d '{
    "params": "..."
  }'

```

There should be no need to pass `"payload_schema": {}`