### PR TITLE
Improve filtering performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,9 @@ debug = true
 [[bench]]
 name = "read_write"
 harness = false
+
+[profile.perf] # for profiling
+inherits = "release"
+debug = 2
+strip = false
+# force-frame-pointers = true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,7 +71,7 @@ if you find this work useful in your research, please consider citing:
 ```bibtex
 @software{smoldb2025,
   author = {kshivendu},
-  title = {kshivendu: a small distributed database built in Rust},
+  title = {smoldb: a smol distributed database built in Rust},
   year = {2025},
   publisher = {github},
   journal = {github repository},

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,3 +37,50 @@ python -m http.server .
 # For flame graph:
 cargo flamegraph --bench upsert -o flamegraph.svg -- --bench
 ```
+
+## Perf investigation:
+
+```sh
+# Ensure cargo.toml has these:
+[profile.release]
+debug = 2
+strip = false
+force-frame-pointers = true
+
+# Terminal 1:
+cargo build -r
+cargo buld -r -p smolbench
+
+# Terminal 1:
+sudo perf record --call-graph dwarf -F 4000 -g ./target/release/smoldb
+
+# Terminal 2:
+./target/release/smolbench --skip-create --skip-upsert --skip-read
+
+# Terminal 1:
+# Stop smoldb once smolbench runs
+sudo chown $USER:$USER perf.data
+hotspot perf.data # Install https://github.com/KDAB/hotspot
+```
+
+```sh
+perf annotate --tui
+```
+
+### Errors:
+
+By default, we use `color-backtrace` crate to show snippets.
+
+## citation
+
+if you find this work useful in your research, please consider citing:
+```bibtex
+@software{smoldb2025,
+  author = {kshivendu},
+  title = {kshivendu: a small distributed database built in Rust},
+  year = {2025},
+  publisher = {github},
+  journal = {github repository},
+  url = {https://github.com/kshivendu/smoldb}
+}
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,18 +41,12 @@ cargo flamegraph --bench upsert -o flamegraph.svg -- --bench
 ## Perf investigation:
 
 ```sh
-# Ensure cargo.toml has these:
-[profile.release]
-debug = 2
-strip = false
-force-frame-pointers = true
+# Terminal 1:
+cargo build --profile perf
+cargo build -r -p smolbench
 
 # Terminal 1:
-cargo build -r
-cargo buld -r -p smolbench
-
-# Terminal 1:
-sudo perf record --call-graph dwarf -F 4000 -g ./target/release/smoldb
+sudo perf record --call-graph dwarf -F 4000 -g ./target/perf/smoldb
 
 # Terminal 2:
 ./target/release/smolbench --skip-create --skip-upsert --skip-read

--- a/src/api/grpc/conversion.rs
+++ b/src/api/grpc/conversion.rs
@@ -16,6 +16,7 @@ impl Query {
                 value: filter.value,
                 op: filter.op.into(),
             },
+            limit: None, // ToDo
         })
     }
 

--- a/src/api/points.rs
+++ b/src/api/points.rs
@@ -121,6 +121,7 @@ async fn list_points(
 #[derive(Deserialize, Clone)]
 pub struct Query {
     pub filter: QueryFilter,
+    pub limit: Option<usize>,
 }
 
 #[actix_web::post("/collections/{collection_name}/query")]
@@ -131,7 +132,13 @@ async fn query_points(
 ) -> impl Responder {
     helpers::time(async {
         let collection_name: String = collection_name.into_inner();
-        let query = query.into_inner();
+        let mut query = query.into_inner();
+
+        // Set default limit if not provided
+        if query.limit.is_none() {
+            query.limit = Some(10); // Default limit
+        }
+
         let result = dispatcher.toc.query_points(&collection_name, query).await;
         match result {
             Ok(points) => Ok(ListPointsResponse { points }),

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,10 @@ pub enum StorageError {
     BadInput(String),
     #[error("Service error: {0}")]
     ServiceError(String),
+    #[error("Sled segment error: {0}")]
+    SledError(#[from] sled::Error),
+    #[error("Serialization/Deserialization error: {0}")]
+    SerdeError(#[from] serde_json::Error),
 }
 
 #[derive(Error, Debug)]

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -521,6 +521,7 @@ mod tests {
 
         let query = Query {
             filter: QueryFilter::new("age", "25", FilterOperator::Gte),
+            limit: None,
         };
 
         let queried_points = collection

--- a/src/storage/index/payload_index.rs
+++ b/src/storage/index/payload_index.rs
@@ -74,6 +74,7 @@ impl IntegerIndex {
         &self,
         value: i64,
         operation: &FilterOperator,
+        limit: Option<usize>,
     ) -> Result<Vec<PointId>, sled::Error> {
         let mut results = Vec::new();
 
@@ -93,6 +94,13 @@ impl IntegerIndex {
                 sled::Error::Io(std::io::Error::other(format!("Failed to decode: {e}")))
             })?;
             results.extend_from_slice(&point_ids);
+
+            if let Some(limit) = limit {
+                if results.len() >= limit {
+                    results.truncate(limit);
+                    break;
+                }
+            }
         }
 
         Ok(results.into_iter().map(PointId::Id).collect())
@@ -239,7 +247,7 @@ impl PayloadIndex {
         match index {
             FieldIndex::Int(int_index) => {
                 let value = query.filter.value.parse::<i64>().unwrap();
-                let query_results = int_index.query(value, &query.filter.op)?;
+                let query_results = int_index.query(value, &query.filter.op, query.limit)?;
                 results.extend(query_results);
             }
             FieldIndex::Null => {
@@ -277,7 +285,7 @@ mod test {
         let field_index = index.indices.get("price").unwrap();
 
         if let FieldIndex::Int(numeric_index) = field_index {
-            let results = numeric_index.query(40, &FilterOperator::Gte).unwrap();
+            let results = numeric_index.query(40, &FilterOperator::Gte, None).unwrap();
             assert_eq!(results.len(), 6); // Points with ids 4, 5, 6, 7, 8, 9
             assert_eq!(results, (4..10).map(PointId::Id).collect::<Vec<_>>());
         } else {

--- a/src/storage/replicas/local_shard.rs
+++ b/src/storage/replicas/local_shard.rs
@@ -28,7 +28,7 @@ pub struct LocalShard {
 impl ShardOperationTrait for LocalShard {
     async fn get_points(&self, ids: Option<Vec<PointId>>) -> CollectionResult<Vec<Point>> {
         if let Some(segment) = self.segments.get(&0) {
-            segment.get_points(ids).map_err(|e| {
+            segment.get_points(ids).await.map_err(|e| {
                 CollectionError::StorageError(StorageError::ServiceError(format!(
                     "Failed to get points from segment: {e}"
                 )))
@@ -54,7 +54,7 @@ impl ShardOperationTrait for LocalShard {
 
     async fn query_points(&self, query: Query) -> CollectionResult<Vec<Point>> {
         if let Some(segment) = self.segments.get(&0) {
-            segment.query_points(query).map_err(|e| {
+            segment.query_points(query).await.map_err(|e| {
                 CollectionError::StorageError(StorageError::ServiceError(format!(
                     "Failed to query points from segment: {e}"
                 )))

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -3,6 +3,7 @@ use crate::{
     error::StorageError,
     storage::index::payload_index::{IndexConfig, PayloadIndex},
 };
+use futures::{stream, StreamExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -103,7 +104,7 @@ impl Segment {
         Ok(())
     }
 
-    pub fn get_points(&self, ids: Option<Vec<PointId>>) -> Result<Vec<Point>, StorageError> {
+    pub async fn get_points(&self, ids: Option<Vec<PointId>>) -> Result<Vec<Point>, StorageError> {
         let mut points = Vec::new();
 
         let Some(ids) = ids else {
@@ -127,25 +128,45 @@ impl Segment {
         };
 
         // If ids are provided, read only those points
-        for id in ids {
-            let key = id.into_string();
-            if let Some(value) = self.db.get(key).map_err(|e| {
-                StorageError::ServiceError(format!("Failed to get point from segment db: {e}"))
-            })? {
-                let point: Point = serde_json::from_slice(&value).map_err(|e| {
-                    StorageError::ServiceError(format!("Failed to deserialize point: {e}"))
-                })?;
-                points.push(point);
-            }
-        }
+        // We need to read them in parallel to speed up (esp since its reading from disk from random locations)
+        let db_inner = self.db.clone(); // sled Db is thread-safe
+        const MAX_CONCURRENT: usize = 10; // If you have too many concurrent tasks, it can hurt performance
+
+        let points: Vec<Point> = stream::iter(ids)
+            .map(|id| {
+                let db = db_inner.clone();
+                async move {
+                    tokio::task::spawn_blocking(move || -> Result<Option<Point>, StorageError> {
+                        let key = id.into_string();
+                        if let Some(value) = db.get(key)? {
+                            let point: Point = serde_json::from_slice(&value)?;
+                            Ok(Some(point))
+                        } else {
+                            Ok(None)
+                        }
+                    })
+                    .await
+                    .map_err(|e| StorageError::ServiceError(format!("Failed to join task: {e}")))?
+                }
+            })
+            .buffer_unordered(MAX_CONCURRENT)
+            .try_filter_map(|result| async move {
+                match result {
+                    Some(point) => Ok(Some(point)),
+                    None => Ok(None), // Point not found, filter out
+                }
+            })
+            .try_collect()
+            .await?;
+
         Ok(points)
     }
 
-    pub fn query_points(&self, query: Query) -> Result<Vec<Point>, StorageError> {
+    pub async fn query_points(&self, query: Query) -> Result<Vec<Point>, StorageError> {
         let point_ids = self.payload_index.query(query).map_err(|e| {
             StorageError::ServiceError(format!("Failed to query payload index: {e}"))
         })?;
-        let points = self.get_points(Some(point_ids))?;
+        let points = self.get_points(Some(point_ids)).await?;
 
         Ok(points)
     }

--- a/src/storage/segment.rs
+++ b/src/storage/segment.rs
@@ -137,8 +137,9 @@ impl Segment {
                 let db = db_inner.clone();
                 async move {
                     tokio::task::spawn_blocking(move || -> Result<Option<Point>, StorageError> {
-                        let key = id.into_string();
+                        let key = id.into_string(); // this is taking small time
                         if let Some(value) = db.get(key)? {
+                            // this takes insane amount of time
                             let point: Point = serde_json::from_slice(&value)?;
                             Ok(Some(point))
                         } else {

--- a/tools/smolbench/src/args.rs
+++ b/tools/smolbench/src/args.rs
@@ -68,7 +68,7 @@ pub struct Args {
     pub skip_read: bool,
 
     /// Check whether to query (with filter) points after upsert
-    #[clap(long, default_value = "true")]
+    #[clap(long, default_value = "false")]
     pub skip_query: bool,
 
     /// Number of 9 digits to show in p99* results

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -62,6 +62,11 @@ async fn main() -> Result<(), SmolBenchError> {
     }
 
     if !args.skip_upsert {
+        println!(
+            "Upserting {} points in batches of {} into collection '{}':",
+            args.num_points, args.batch_size, args.collection_name
+        );
+
         let batch_responses = upsert_points(
             &args.uri,
             &args.collection_name,
@@ -71,34 +76,33 @@ async fn main() -> Result<(), SmolBenchError> {
         )
         .await?;
 
-        println!(
-            "Upserted {} points in batches of {} into collection '{}':",
-            args.num_points, args.batch_size, args.collection_name
-        );
-
         log_latencies(&batch_responses, args.p9, "server-side batched upsert").await?;
     }
 
     if !args.skip_read {
         let num_queries = args.num_points.min(1000) as u64;
+        println!(
+            "Reading {} points from collection '{}':",
+            num_queries, args.collection_name,
+        );
+
         let mut rnd = rand::rng();
         let ids = (0..num_queries)
             .map(|_| rnd.random::<u64>() % args.num_points as u64) // Assume that IDs in the range [0, num_points) have been upserted
             .collect::<Vec<_>>();
         let responses = read_point(&args.uri, &args.collection_name, ids).await?;
-        println!(
-            "Read {} points from collection '{}':",
-            responses.len(),
-            args.collection_name,
-        );
 
         log_latencies(&responses, args.p9, "server-side read").await?;
     }
 
     if !args.skip_query {
-        let num_queries = args.num_points.min(100) as u64;
-        let mut rnd = rand::rng();
+        let num_queries = (args.num_points as f32 * 0.01).max(100_f32) as u64;
+        println!(
+            "Querying {} points with concurrency of {} from collection '{}' with price filter",
+            num_queries, args.concurrent_queries, args.collection_name,
+        );
 
+        let mut rnd = rand::rng();
         let futures = (0..num_queries)
             .map(|_| {
                 let price_gte = rnd.random::<i64>() % args.num_points as i64;
@@ -120,13 +124,6 @@ async fn main() -> Result<(), SmolBenchError> {
             .buffered(args.concurrent_queries)
             .try_collect::<Vec<_>>()
             .await?;
-
-        println!(
-            "Queried {} points with concurrency of {} from collection '{}' with price filter",
-            responses.len(),
-            args.concurrent_queries,
-            args.collection_name,
-        );
 
         log_latencies(&responses, args.p9, "server-side query").await?;
     }


### PR DESCRIPTION
Related to https://github.com/KShivendu/smoldb/issues/73



```sh
# Assuming collection is created using the command from the original GH issue
# https://github.com/KShivendu/smoldb/issues/73

# Before:
$ ./target/release/smolbench --skip-create --skip-upsert --skip-read
Queried 100 points with concurrency of 10 from collection 'benchmark' with price filter
Avg server-side query latency: 77.61 ms
Min server-side query latency: 0.02 ms
p50 server-side query latency: 0.08 ms
p95 server-side query latency: 307.07 ms
p99 server-side query latency: 368.88 ms
Max server-side query latency: 368.88 ms

# After:
$ ./target/release/smolbench --skip-create --skip-upsert --skip-read
Queried 100 points with concurrency of 10 from collection 'benchmark' with price filter
Avg server-side query latency: 0.84 ms # ===> 77.61 / 0.84 = 92x improvement
Min server-side query latency: 0.02 ms
p50 server-side query latency: 0.33 ms
p95 server-side query latency: 4.55 ms # ===> 307.07 / 4.55 = 67x improvement
p99 server-side query latency: 5.13 ms
Max server-side query latency: 5.13 ms
```

~WIP: Tried to investigate perf bottnecks using [hotspot](https://github.com/KDAB/hotspot). But I still don't find the perf satisfactory~ 

<img width="1899" height="775" alt="Hotspot Flamegraph" src="https://github.com/user-attachments/assets/9206cb82-9101-41ec-853c-324121fbbd66" />

Update: I was mainly not using limit. That's why I didn't see any odd function/system calls. It was reading too many points.

ToDo:
- [ ] Use `bincode` instead of `serde_json`?
- [ ] Add proper benchmark in `benches`
- [x] Investigate why async concurrent workers seem to be performing worse? 
  - It was a good idea but since we were reading too many points (no limit) things got worse. This [comment](https://github.com/KShivendu/smoldb/pull/76#issuecomment-3382181789) shows before/after of using concurrent workers.
- [x] Add limit
  - This was the real bottleneck. It was reading thousands of points (upto 100k) on avg from disk for each query. :facepalm: 
- [ ] Add offset since all points should remain queriable after adding limit. 