### PR TITLE
Introduce text index for full text search

### DIFF
--- a/benches/collection/main.rs
+++ b/benches/collection/main.rs
@@ -1,6 +1,7 @@
 mod common;
 mod query;
 mod read;
+mod text_search;
 mod write;
 
 use criterion::{criterion_group, criterion_main};
@@ -12,6 +13,8 @@ criterion_group!(
     read::single_read,
     read::concurrent_read,
     query::single_query,
-    query::concurrent_query
+    query::concurrent_query,
+    text_search::single_text_query,
+    text_search::concurrent_text_query
 );
 criterion_main!(benches);

--- a/benches/collection/query.rs
+++ b/benches/collection/query.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use criterion::Criterion;
+use serde_json::Value;
 
 use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
@@ -28,14 +29,14 @@ pub fn single_query(c: &mut Criterion) {
             &tempdir,
             channel_service,
             Some(payload_index),
-            generate_points(1),
+            generate_points(1), // todo: Should have 100_000 points but query only for a single point
         )
         .await
     });
     let collection_arc = Arc::new(collection);
 
     let query = Query {
-        filter: QueryFilter::new("price", "0", FilterOperator::Gte),
+        filter: QueryFilter::new("price", Value::from(0), FilterOperator::Gte),
         limit: Some(10),
     };
 
@@ -75,11 +76,7 @@ pub fn concurrent_query(c: &mut Criterion) {
         .map(|i| {
             let start_id = i * chunk_size as u64;
             Query {
-                filter: QueryFilter::new(
-                    "price",
-                    format!("{}", start_id * 10),
-                    FilterOperator::Gte,
-                ),
+                filter: QueryFilter::new("price", Value::from(start_id * 10), FilterOperator::Gte),
                 limit: Some(10),
             }
         })

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -1,0 +1,95 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use criterion::Criterion;
+
+use crate::common::{
+    benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
+    create_tempdir, generate_points,
+};
+use smoldb::{
+    api::points::Query,
+    storage::index::{
+        filter::{FilterOperator, QueryFilter},
+        payload_index::IndexConfig,
+    },
+};
+
+// Perf when bench was first implemented: 31.807 µs
+pub fn single_text_query(c: &mut Criterion) {
+    let mut group = benchmark_group(c, "Single text query benchmarks");
+
+    let rt = create_runtime();
+    let tempdir = create_tempdir();
+    let channel_service = create_channel_service();
+    let num_points = 100_000;
+
+    let collection = rt.block_on(async {
+        let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
+        create_collection_with_points(
+            &tempdir,
+            channel_service,
+            Some(payload_index),
+            generate_points(num_points),
+        )
+        .await
+    });
+    let collection_arc = Arc::new(collection);
+
+    let query = Query {
+        filter: QueryFilter::new("text", "100", FilterOperator::Eq),
+        limit: Some(10),
+    };
+
+    group.bench_function("single_text_query", |b| {
+        b.to_async(&rt).iter(|| async {
+            collection_arc
+                .query_points(query.clone(), true)
+                .await
+                .unwrap();
+        })
+    });
+}
+
+// Perf when bench was first implemented: 668.48 µs
+pub fn concurrent_text_query(c: &mut Criterion) {
+    let mut group = benchmark_group(c, "Concurrent text query benchmarks");
+
+    let rt = create_runtime();
+    let tempdir = create_tempdir();
+
+    let num_points = 100_000;
+    let num_threads = 4;
+    let chunk_size = (num_points / num_threads) as usize;
+
+    let points = generate_points(num_points);
+
+    let channel_service = create_channel_service();
+
+    let collection = rt.block_on(async {
+        let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
+        create_collection_with_points(&tempdir, channel_service, Some(payload_index), points).await
+    });
+    let collection_arc = Arc::new(collection);
+
+    // Create queries for different chunks - filtering on different message values
+    let queries: Vec<Query> = (0..num_threads)
+        .map(|i| {
+            let start_id = i * chunk_size as u64;
+            Query {
+                filter: QueryFilter::new("text", format!("{start_id}"), FilterOperator::Gte),
+                limit: Some(10),
+            }
+        })
+        .collect();
+
+    group.bench_function("concurrent_text_query", |b| {
+        b.to_async(&rt).iter(|| async {
+            for query in &queries {
+                collection_arc
+                    .query_points(query.clone(), true)
+                    .await
+                    .unwrap();
+            }
+        })
+    });
+}

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use criterion::Criterion;
+use serde_json::Value;
 
 use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
@@ -14,7 +15,7 @@ use smoldb::{
     },
 };
 
-// Perf when bench was first implemented: 31.807 µs
+// Perf when bench was first implemented: 1.5804 µs
 pub fn single_text_query(c: &mut Criterion) {
     let mut group = benchmark_group(c, "Single text query benchmarks");
 
@@ -36,7 +37,7 @@ pub fn single_text_query(c: &mut Criterion) {
     let collection_arc = Arc::new(collection);
 
     let query = Query {
-        filter: QueryFilter::new("text", "100", FilterOperator::Eq),
+        filter: QueryFilter::new("text", Value::from("100"), FilterOperator::Eq),
         limit: Some(10),
     };
 
@@ -50,7 +51,7 @@ pub fn single_text_query(c: &mut Criterion) {
     });
 }
 
-// Perf when bench was first implemented: 668.48 µs
+// Perf when bench was first implemented: 5.7696 µs
 pub fn concurrent_text_query(c: &mut Criterion) {
     let mut group = benchmark_group(c, "Concurrent text query benchmarks");
 
@@ -76,7 +77,11 @@ pub fn concurrent_text_query(c: &mut Criterion) {
         .map(|i| {
             let start_id = i * chunk_size as u64;
             Query {
-                filter: QueryFilter::new("text", format!("{start_id}"), FilterOperator::Gte),
+                filter: QueryFilter::new(
+                    "text",
+                    Value::from(format!("{start_id}")),
+                    FilterOperator::Gte,
+                ),
                 limit: Some(10),
             }
         })

--- a/src/api/grpc/conversion.rs
+++ b/src/api/grpc/conversion.rs
@@ -10,10 +10,12 @@ impl Query {
             .filter
             .ok_or_else(|| "Query filter is required".to_string())?;
 
+        let value = serde_json::from_str(&filter.value).expect("Failed to convert value to string");
+
         Ok(Self {
             filter: QueryFilter {
                 key: filter.key,
-                value: filter.value,
+                value,
                 op: filter.op.try_into()?,
             },
             limit: None, // ToDo
@@ -21,10 +23,14 @@ impl Query {
     }
 
     pub fn into_grpc(self) -> Option<GrpcQueryPointsParams> {
+        // todo: cleaner error handling
+        let value =
+            serde_json::to_string(&self.filter.value).expect("Failed to convert value to string");
+
         Some(GrpcQueryPointsParams {
             filter: Some(crate::api::grpc::schema::QueryFilter {
                 key: self.filter.key,
-                value: self.filter.value,
+                value,
                 op: self.filter.op.as_str().to_string(),
             }),
         })

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -521,7 +521,7 @@ mod tests {
         assert_eq!(read_points[0], points[0]);
 
         let query = Query {
-            filter: QueryFilter::new("age", "25", FilterOperator::Gte),
+            filter: QueryFilter::new("age", json!(25), FilterOperator::Gte),
             limit: None,
         };
 

--- a/src/storage/segment/index/filter.rs
+++ b/src/storage/segment/index/filter.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
@@ -40,12 +41,13 @@ impl std::convert::TryFrom<String> for FilterOperator {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct QueryFilter {
     pub key: String,
-    pub value: String,
+    // todo: Limit types of values?
+    pub value: Value,
     pub op: FilterOperator,
 }
 
 impl QueryFilter {
-    pub fn new(key: impl Into<String>, value: impl Into<String>, op: FilterOperator) -> Self {
+    pub fn new(key: impl Into<String>, value: impl Into<Value>, op: FilterOperator) -> Self {
         Self {
             key: key.into(),
             value: value.into(),

--- a/src/storage/segment/index/integer.rs
+++ b/src/storage/segment/index/integer.rs
@@ -1,0 +1,106 @@
+use std::ops::Bound;
+
+use serde_json::Value;
+use sled::Db;
+
+use crate::storage::{
+    index::{
+        filter::FilterOperator,
+        payload_index::{decoded_point_ids, encoded_integer_value, encoded_point_ids},
+    },
+    segment::PointId,
+};
+
+pub struct IntegerIndex(sled::Tree);
+
+impl IntegerIndex {
+    pub fn open(db: &Db, name: &str) -> Self {
+        let tree = db
+            .open_tree(format!("{name}_numeric_index"))
+            .expect("Failed to open sled tree");
+        Self(tree)
+    }
+
+    pub fn upsert(&self, point_id: u64, value: i64) -> Result<(), sled::Error> {
+        // In numeric tree, the point value becomes tree's key, and the point ID is part of a list of values.
+        let tree_key = encoded_integer_value(value);
+
+        // Fetch existing point IDs for this value
+        let mut point_ids: Vec<u64> = self
+            .0
+            .get(&tree_key)?
+            .map(|data| {
+                decoded_point_ids(&data)
+                    .unwrap_or_else(|e| panic!("Failed to decode point IDs: {e}"))
+            })
+            .unwrap_or_default();
+
+        // Add point and sort
+        point_ids.push(point_id);
+        point_ids.sort();
+
+        // Store back
+        let encoded_ids = encoded_point_ids(&point_ids).map_err(|e| {
+            sled::Error::Io(std::io::Error::other(format!(
+                "Failed to encode point IDs: {e}"
+            )))
+        })?;
+
+        self.0.insert(&tree_key, encoded_ids).map_err(|e| {
+            sled::Error::Io(std::io::Error::other(format!(
+                "Failed to insert into index tree: {e}"
+            )))
+        })?;
+
+        Ok(())
+    }
+
+    pub fn query(
+        &self,
+        value: i64,
+        operation: &FilterOperator,
+        limit: Option<usize>,
+    ) -> Result<Vec<PointId>, sled::Error> {
+        let mut results = Vec::new();
+
+        let value = encoded_integer_value(value);
+
+        let bounds = match operation {
+            FilterOperator::Gte => (Bound::Included(value), Bound::Unbounded),
+            FilterOperator::Gt => (Bound::Excluded(value), Bound::Unbounded),
+            FilterOperator::Lt => (Bound::Unbounded, Bound::Excluded(value)),
+            FilterOperator::Lte => (Bound::Unbounded, Bound::Included(value)),
+            FilterOperator::Eq => (Bound::Included(value.clone()), Bound::Included(value)),
+        };
+
+        for item in self.0.range(bounds) {
+            let (_gte_value, encoded_point_ids) = item?;
+            let point_ids = decoded_point_ids(&encoded_point_ids).map_err(|e| {
+                sled::Error::Io(std::io::Error::other(format!("Failed to decode: {e}")))
+            })?;
+            results.extend_from_slice(&point_ids);
+
+            if let Some(limit) = limit {
+                if results.len() >= limit {
+                    results.truncate(limit);
+                    break;
+                }
+            }
+        }
+
+        Ok(results.into_iter().map(PointId::Id).collect())
+    }
+
+    pub fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error> {
+        match value {
+            Value::Number(num) if num.is_i64() => {
+                let num_value = num.as_i64().unwrap();
+                self.upsert(point_id, num_value)
+            }
+            _ => Err(sled::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("{value} is not a valid i64 value"),
+            ))),
+        }
+    }
+}

--- a/src/storage/segment/index/integer.rs
+++ b/src/storage/segment/index/integer.rs
@@ -1,7 +1,6 @@
-use std::ops::Bound;
-
 use serde_json::Value;
 use sled::Db;
+use std::ops::Bound;
 
 use crate::storage::{
     index::{

--- a/src/storage/segment/index/mod.rs
+++ b/src/storage/segment/index/mod.rs
@@ -1,2 +1,4 @@
 pub mod filter;
+pub mod integer;
 pub mod payload_index;
+pub mod text;

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -1,17 +1,14 @@
 use crate::{
     api::points::Query,
     storage::{
-        index::filter::FilterOperator,
+        index::{filter::FilterOperator, integer::IntegerIndex, text::TextIndex},
         segment::{Point, PointId},
     },
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sled::Db;
-use std::{
-    collections::{HashMap, HashSet},
-    ops::Bound,
-};
+use std::collections::{HashMap, HashSet};
 use utoipa::ToSchema;
 
 /// Converts the number into a big-endian value which is suitable for querying/storing in sled
@@ -28,89 +25,10 @@ pub fn decoded_point_ids(data: &[u8]) -> Result<Vec<u64>, bincode::error::Decode
     bincode::decode_from_slice(data, bincode::config::standard()).map(|(ids, _)| ids)
 }
 
-pub struct IntegerIndex(sled::Tree);
-impl IntegerIndex {
-    pub fn open(db: &Db, name: &str) -> Self {
-        let tree = db
-            .open_tree(format!("{name}_numeric_index"))
-            .expect("Failed to open sled tree");
-        Self(tree)
-    }
-
-    pub fn upsert(&self, point_id: u64, value: i64) -> Result<(), sled::Error> {
-        // In numeric tree, the point value becomes tree's key, and the point ID is part of a list of values.
-        let tree_key = encoded_integer_value(value);
-
-        // Fetch existing point IDs for this value
-        let mut point_ids: Vec<u64> = self
-            .0
-            .get(&tree_key)?
-            .map(|data| {
-                decoded_point_ids(&data)
-                    .unwrap_or_else(|e| panic!("Failed to decode point IDs: {e}"))
-            })
-            .unwrap_or_default();
-
-        // Add point and sort
-        point_ids.push(point_id);
-        point_ids.sort();
-
-        // Store back
-        let encoded_ids = encoded_point_ids(&point_ids).map_err(|e| {
-            sled::Error::Io(std::io::Error::other(format!(
-                "Failed to encode point IDs: {e}"
-            )))
-        })?;
-
-        self.0.insert(&tree_key, encoded_ids).map_err(|e| {
-            sled::Error::Io(std::io::Error::other(format!(
-                "Failed to insert into index tree: {e}"
-            )))
-        })?;
-
-        Ok(())
-    }
-
-    pub fn query(
-        &self,
-        value: i64,
-        operation: &FilterOperator,
-        limit: Option<usize>,
-    ) -> Result<Vec<PointId>, sled::Error> {
-        let mut results = Vec::new();
-
-        let value = encoded_integer_value(value);
-
-        let bounds = match operation {
-            FilterOperator::Gte => (Bound::Included(value), Bound::Unbounded),
-            FilterOperator::Gt => (Bound::Excluded(value), Bound::Unbounded),
-            FilterOperator::Lt => (Bound::Unbounded, Bound::Excluded(value)),
-            FilterOperator::Lte => (Bound::Unbounded, Bound::Included(value)),
-            FilterOperator::Eq => (Bound::Included(value.clone()), Bound::Included(value)),
-        };
-
-        for item in self.0.range(bounds) {
-            let (_gte_value, encoded_point_ids) = item?;
-            let point_ids = decoded_point_ids(&encoded_point_ids).map_err(|e| {
-                sled::Error::Io(std::io::Error::other(format!("Failed to decode: {e}")))
-            })?;
-            results.extend_from_slice(&point_ids);
-
-            if let Some(limit) = limit {
-                if results.len() >= limit {
-                    results.truncate(limit);
-                    break;
-                }
-            }
-        }
-
-        Ok(results.into_iter().map(PointId::Id).collect())
-    }
-}
-
 pub enum FieldIndex {
     Int(IntegerIndex),
     Null,
+    Text(TextIndex),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, ToSchema)]
@@ -118,28 +36,25 @@ pub enum FieldIndex {
 pub enum IndexConfig {
     Int,
     Null,
+    Text,
 }
 
 impl FieldIndex {
-    pub fn numeric(db: &Db, name: &str) -> Self {
+    pub fn new_numeric(db: &Db, name: &str) -> Self {
         FieldIndex::Int(IntegerIndex::open(db, name))
+    }
+
+    pub fn new_text(db: &Db, name: &str) -> Self {
+        FieldIndex::Text(TextIndex::open(db, name))
     }
 
     pub fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error> {
         match self {
-            FieldIndex::Int(index) => match value {
-                Value::Number(num) if num.is_i64() => {
-                    let num_value = num.as_i64().unwrap();
-                    index.upsert(point_id, num_value)
-                }
-                _ => Err(sled::Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("{value} is not a valid i64 value"),
-                ))),
-            },
+            FieldIndex::Int(index) => index.add_point(point_id, value),
             FieldIndex::Null => {
                 unimplemented!("Null index is not implemented yet");
             }
+            FieldIndex::Text(t) => t.add_point(point_id, value),
         }
     }
 }
@@ -161,8 +76,9 @@ impl PayloadIndex {
             let index_config: IndexConfig =
                 serde_json::from_slice(&value).expect("Failed to deserialize index config");
             let field_index = match index_config {
-                IndexConfig::Int => FieldIndex::numeric(db, &name),
+                IndexConfig::Int => FieldIndex::new_numeric(db, &name),
                 IndexConfig::Null => FieldIndex::Null,
+                IndexConfig::Text => FieldIndex::new_text(db, &name),
             };
             indices.insert(name, field_index);
         }
@@ -188,8 +104,9 @@ impl PayloadIndex {
         }
 
         let index = match index_config {
-            IndexConfig::Int => FieldIndex::numeric(db, name),
+            IndexConfig::Int => FieldIndex::new_numeric(db, name),
             IndexConfig::Null => FieldIndex::Null,
+            IndexConfig::Text => FieldIndex::new_text(db, name),
         };
 
         let index_config_str =
@@ -206,6 +123,8 @@ impl PayloadIndex {
         Ok(())
     }
 
+    /// ToDo: Support updating existing points in the index. This would require removing old values and adding new ones.
+    /// ToDo: Decoupling indexing from upserts. So that we can upsert fast and index in the background.
     pub fn upsert(&self, point: &Point) -> Result<(), sled::Error> {
         let PointId::Id(point_id) = point.id else {
             return Err(sled::Error::Io(std::io::Error::new(
@@ -244,9 +163,32 @@ impl PayloadIndex {
             FieldIndex::Null => {
                 unimplemented!("Null index queries are not implemented yet");
             }
+            FieldIndex::Text(t) => {
+                let value = &query.filter.value;
+                let query_results = t.query(
+                    &Value::String(value.to_string()),
+                    &FilterOperator::Eq,
+                    query.limit,
+                )?;
+                results.extend(query_results);
+            }
         }
         Ok(results.into_iter().collect())
     }
+}
+
+pub trait FieldIndexTrait {
+    /// Create or load an index from the DB
+    fn open(db: &Db, name: &str) -> Self;
+    /// Add a point to the index
+    fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error>;
+    /// Query the index
+    fn query(
+        &self,
+        value: &Value,
+        operation: &FilterOperator,
+        limit: Option<usize>,
+    ) -> Result<Vec<PointId>, sled::Error>;
 }
 
 #[cfg(test)]

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -75,7 +75,7 @@ impl FieldIndexTrait<&Value> for FieldIndex {
                 let value = value.as_i64().ok_or_else(|| {
                     sled::Error::Io(std::io::Error::new(
                         std::io::ErrorKind::InvalidInput,
-                        "Integer index query value must be an integer",
+                        format!("Integer index query value must be an integer. Found {value}"),
                     ))
                 })?;
 
@@ -196,11 +196,7 @@ impl PayloadIndex {
 
         // Todo: Support combining results from multiple indices for complex queries
 
-        let results = index.query(
-            &Value::String(query.filter.value),
-            &query.filter.op,
-            query.limit,
-        )?;
+        let results = index.query(&query.filter.value, &query.filter.op, query.limit)?;
 
         Ok(results)
     }

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -92,7 +92,7 @@ impl FieldIndexTrait<&Value> for FieldIndex {
                     )));
                 };
 
-                t.query(&value, &FilterOperator::Eq, limit)?
+                t.query(value, &FilterOperator::Eq, limit)?
             }
         };
 

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -85,12 +85,12 @@ impl FieldIndexTrait<&Value> for FieldIndex {
                 unimplemented!("Null index queries are not implemented yet");
             }
             FieldIndex::Text(t) => {
-                let Some(value) = value.as_str() else {
-                    return Err(sled::Error::Io(std::io::Error::new(
+                let value = value.as_str().ok_or_else(|| {
+                    sled::Error::Io(std::io::Error::new(
                         std::io::ErrorKind::InvalidInput,
-                        "Text index query value must be a string",
-                    )));
-                };
+                        format!("Text index query value must be a string. Found {value}"),
+                    ))
+                })?;
 
                 t.query(value, &FilterOperator::Eq, limit)?
             }

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -167,6 +167,7 @@ impl PayloadIndex {
     /// ToDo: Support updating existing points in the index. This would require removing old values and adding new ones.
     /// ToDo: Decoupling indexing from upserts. So that we can upsert fast and index in the background.
     pub fn upsert(&self, point: &Point) -> Result<(), sled::Error> {
+        // todo: Use id tracker so that we can support different PointId types while being storage efficient.
         let PointId::Id(point_id) = point.id else {
             return Err(sled::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -8,7 +8,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sled::Db;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use utoipa::ToSchema;
 
 /// Converts the number into a big-endian value which is suitable for querying/storing in sled
@@ -47,15 +47,56 @@ impl FieldIndex {
     pub fn new_text(db: &Db, name: &str) -> Self {
         FieldIndex::Text(TextIndex::open(db, name))
     }
+}
 
-    pub fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error> {
+impl FieldIndexTrait<&Value> for FieldIndex {
+    fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error> {
         match self {
             FieldIndex::Int(index) => index.add_point(point_id, value),
             FieldIndex::Null => {
                 unimplemented!("Null index is not implemented yet");
             }
-            FieldIndex::Text(t) => t.add_point(point_id, value),
+            FieldIndex::Text(index) => index.add_point(point_id, value),
         }
+    }
+
+    fn open(_db: &Db, _name: &str) -> Self {
+        unimplemented!("Use specific index constructors like new_numeric or new_text");
+    }
+
+    fn query(
+        &self,
+        value: &Value,
+        operation: &FilterOperator,
+        limit: Option<usize>,
+    ) -> Result<Vec<PointId>, sled::Error> {
+        let results = match self {
+            FieldIndex::Int(int_index) => {
+                let value = value.as_i64().ok_or_else(|| {
+                    sled::Error::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "Integer index query value must be an integer",
+                    ))
+                })?;
+
+                int_index.query(value, operation, limit)?
+            }
+            FieldIndex::Null => {
+                unimplemented!("Null index queries are not implemented yet");
+            }
+            FieldIndex::Text(t) => {
+                let Some(value) = value.as_str() else {
+                    return Err(sled::Error::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "Text index query value must be a string",
+                    )));
+                };
+
+                t.query(&value, &FilterOperator::Eq, limit)?
+            }
+        };
+
+        Ok(results)
     }
 }
 
@@ -105,7 +146,7 @@ impl PayloadIndex {
 
         let index = match index_config {
             IndexConfig::Int => FieldIndex::new_numeric(db, name),
-            IndexConfig::Null => FieldIndex::Null,
+            IndexConfig::Null => unimplemented!("Null index is not implemented yet"),
             IndexConfig::Text => FieldIndex::new_text(db, name),
         };
 
@@ -144,8 +185,6 @@ impl PayloadIndex {
     // Todo: Support deleting points from the index in case of update or deletes
 
     pub fn query(&self, query: Query) -> Result<Vec<PointId>, sled::Error> {
-        let mut results = HashSet::new();
-
         // ToDo: Should allow querying for un-indexed fields to demonstrate/benchmark difference
         let index = self.indices.get(&query.filter.key).ok_or_else(|| {
             sled::Error::Io(std::io::Error::new(
@@ -154,30 +193,19 @@ impl PayloadIndex {
             ))
         })?;
 
-        match index {
-            FieldIndex::Int(int_index) => {
-                let value = query.filter.value.parse::<i64>().unwrap();
-                let query_results = int_index.query(value, &query.filter.op, query.limit)?;
-                results.extend(query_results);
-            }
-            FieldIndex::Null => {
-                unimplemented!("Null index queries are not implemented yet");
-            }
-            FieldIndex::Text(t) => {
-                let value = &query.filter.value;
-                let query_results = t.query(
-                    &Value::String(value.to_string()),
-                    &FilterOperator::Eq,
-                    query.limit,
-                )?;
-                results.extend(query_results);
-            }
-        }
-        Ok(results.into_iter().collect())
+        // Todo: Support combining results from multiple indices for complex queries
+
+        let results = index.query(
+            &Value::String(query.filter.value),
+            &query.filter.op,
+            query.limit,
+        )?;
+
+        Ok(results)
     }
 }
 
-pub trait FieldIndexTrait {
+pub trait FieldIndexTrait<DataType> {
     /// Create or load an index from the DB
     fn open(db: &Db, name: &str) -> Self;
     /// Add a point to the index
@@ -185,7 +213,7 @@ pub trait FieldIndexTrait {
     /// Query the index
     fn query(
         &self,
-        value: &Value,
+        value: DataType,
         operation: &FilterOperator,
         limit: Option<usize>,
     ) -> Result<Vec<PointId>, sled::Error>;

--- a/src/storage/segment/index/text.rs
+++ b/src/storage/segment/index/text.rs
@@ -1,9 +1,12 @@
 use serde_json::Value;
 use sled::Db;
 
-use crate::storage::index::{
-    filter::FilterOperator,
-    payload_index::{decoded_point_ids, encoded_point_ids, FieldIndexTrait},
+use crate::storage::{
+    index::{
+        filter::FilterOperator,
+        payload_index::{decoded_point_ids, encoded_point_ids, FieldIndexTrait},
+    },
+    segment::PointId,
 };
 
 pub struct TextIndex(sled::Tree);
@@ -54,7 +57,7 @@ impl TextIndex {
     }
 }
 
-impl FieldIndexTrait for TextIndex {
+impl FieldIndexTrait<&str> for TextIndex {
     fn open(db: &Db, name: &str) -> Self {
         let tree = db
             .open_tree(format!("{name}_text_index"))
@@ -74,23 +77,16 @@ impl FieldIndexTrait for TextIndex {
 
     fn query(
         &self,
-        value: &serde_json::Value,
+        value: &str,
         _operation: &FilterOperator, // todo: Remove operation for text index?
         limit: Option<usize>,
-    ) -> Result<Vec<crate::storage::segment::PointId>, sled::Error> {
-        let Some(term) = value.as_str() else {
-            return Err(sled::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Text index query value must be a string",
-            )));
-        };
-
+    ) -> Result<Vec<PointId>, sled::Error> {
         let mut results = Vec::new();
-        let term_key = term.as_bytes();
+        let query_key = value.as_bytes();
 
         let point_ids: Vec<u64> = self
             .0
-            .get(term_key)?
+            .get(query_key)?
             .map(|data| {
                 // Decode existing point IDs for this term
                 decoded_point_ids(&data)
@@ -99,7 +95,7 @@ impl FieldIndexTrait for TextIndex {
             .unwrap_or_default();
 
         for point_id in point_ids {
-            results.push(crate::storage::segment::PointId::Id(point_id));
+            results.push(PointId::Id(point_id));
             if let Some(lim) = limit {
                 if results.len() >= lim {
                     break;

--- a/src/storage/segment/index/text.rs
+++ b/src/storage/segment/index/text.rs
@@ -1,0 +1,115 @@
+use serde_json::Value;
+use sled::Db;
+
+use crate::storage::index::{
+    filter::FilterOperator,
+    payload_index::{decoded_point_ids, encoded_point_ids, FieldIndexTrait},
+};
+
+pub struct TextIndex(sled::Tree);
+
+// Full text search index implementation with posting lists
+impl TextIndex {
+    pub fn upsert(&self, point_id: u64, text: &String) -> Result<(), sled::Error> {
+        // TODO: Add stop words, stemming, etc based on language
+        // We need to tokenize the text into terms
+        let terms: Vec<&str> = text.split_whitespace().collect();
+
+        // In this tree, the term becomes the key, and the point/doc ID is part of a list of values.
+
+        for term in terms {
+            let term_key = term.as_bytes();
+
+            let mut point_ids: Vec<u64> = self
+                .0
+                .get(&term_key)?
+                .map(|data| {
+                    // Decode existing point IDs for this term
+                    // Todo: Apply delta encoding??
+                    decoded_point_ids(&data).unwrap_or_else(|e| {
+                        panic!("Failed to decode point IDs from posting list: {e}")
+                    })
+                })
+                .unwrap_or_default();
+
+            // Add point and sort
+            point_ids.push(point_id);
+            point_ids.sort();
+
+            // Store back
+            let encoded_ids = encoded_point_ids(&point_ids).map_err(|e| {
+                sled::Error::Io(std::io::Error::other(format!(
+                    "Failed to encode point IDs for posting list: {e}"
+                )))
+            })?;
+
+            self.0.insert(&term_key, encoded_ids).map_err(|e| {
+                sled::Error::Io(std::io::Error::other(format!(
+                    "Failed to insert into text index tree: {e}"
+                )))
+            })?;
+        }
+
+        Ok(())
+    }
+}
+
+impl FieldIndexTrait for TextIndex {
+    fn open(db: &Db, name: &str) -> Self {
+        let tree = db
+            .open_tree(format!("{name}_text_index"))
+            .expect("Failed to open sled tree");
+        Self(tree)
+    }
+
+    fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error> {
+        match value {
+            Value::String(text) => self.upsert(point_id, text),
+            _ => Err(sled::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("{value} is not a valid string value"),
+            ))),
+        }
+    }
+
+    fn query(
+        &self,
+        value: &serde_json::Value,
+        _operation: &FilterOperator, // todo: Remove operation for text index?
+        limit: Option<usize>,
+    ) -> Result<Vec<crate::storage::segment::PointId>, sled::Error> {
+        let Some(term) = value.as_str() else {
+            return Err(sled::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Text index query value must be a string",
+            )));
+        };
+
+        let mut results = Vec::new();
+        let term_key = term.as_bytes();
+
+        let point_ids: Vec<u64> = self
+            .0
+            .get(&term_key)?
+            .map(|data| {
+                // Decode existing point IDs for this term
+                decoded_point_ids(&data)
+                    .unwrap_or_else(|e| panic!("Failed to decode point IDs from posting list: {e}"))
+            })
+            .unwrap_or_default();
+
+        for point_id in point_ids {
+            results.push(crate::storage::segment::PointId::Id(point_id));
+            if let Some(lim) = limit {
+                if results.len() >= lim {
+                    break;
+                }
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+// TextIndex is basically going to be {term -> list of point ids}
+//

--- a/src/storage/segment/index/text.rs
+++ b/src/storage/segment/index/text.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, sync::RwLock};
+
 use serde_json::Value;
 use sled::Db;
 
@@ -9,7 +11,11 @@ use crate::storage::{
     segment::PointId,
 };
 
-pub struct TextIndex(sled::Tree);
+pub struct TextIndex {
+    db: sled::Tree,
+    in_memory_index: InMemoryTextIndex,
+    use_in_memory: bool,
+}
 
 // Full text search index implementation with posting lists
 impl TextIndex {
@@ -24,7 +30,7 @@ impl TextIndex {
             let term_key = term.as_bytes();
 
             let mut point_ids: Vec<u64> = self
-                .0
+                .db
                 .get(term_key)?
                 .map(|data| {
                     // Decode existing point IDs for this term
@@ -46,11 +52,15 @@ impl TextIndex {
                 )))
             })?;
 
-            self.0.insert(term_key, encoded_ids).map_err(|e| {
+            self.db.insert(term_key, encoded_ids).map_err(|e| {
                 sled::Error::Io(std::io::Error::other(format!(
                     "Failed to insert into text index tree: {e}"
                 )))
             })?;
+
+            if self.use_in_memory {
+                self.in_memory_index.override_posting_list(term, point_ids);
+            }
         }
 
         Ok(())
@@ -62,7 +72,14 @@ impl FieldIndexTrait<&str> for TextIndex {
         let tree = db
             .open_tree(format!("{name}_text_index"))
             .expect("Failed to open sled tree");
-        Self(tree)
+
+        let in_memory_index = InMemoryTextIndex::new(db);
+
+        Self {
+            db: tree,
+            in_memory_index,
+            use_in_memory: false,
+        }
     }
 
     fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error> {
@@ -81,11 +98,20 @@ impl FieldIndexTrait<&str> for TextIndex {
         _operation: &FilterOperator, // todo: Remove operation for text index?
         limit: Option<usize>,
     ) -> Result<Vec<PointId>, sled::Error> {
+        if self.use_in_memory {
+            return Ok(self
+                .in_memory_index
+                .query(value, limit)
+                .into_iter()
+                .map(PointId::Id)
+                .collect());
+        }
+
         let mut results = Vec::new();
         let query_key = value.as_bytes();
 
         let point_ids: Vec<u64> = self
-            .0
+            .db
             .get(query_key)?
             .map(|data| {
                 // Decode existing point IDs for this term
@@ -107,5 +133,39 @@ impl FieldIndexTrait<&str> for TextIndex {
     }
 }
 
-// TextIndex is basically going to be {term -> list of point ids}
-//
+struct InMemoryTextIndex {
+    // Todo: Use ahashmap here
+    index: RwLock<HashMap<String, Vec<u64>>>,
+}
+
+impl InMemoryTextIndex {
+    pub fn new(db: &Db) -> Self {
+        let mut index = HashMap::new();
+
+        for item in db.iter() {
+            let (key, value) = item.expect("Failed to read text index item");
+            let term = String::from_utf8(key.to_vec()).expect("Invalid UTF-8 in key");
+            let point_ids = decoded_point_ids(&value).expect("Failed to decode point IDs");
+            index.insert(term, point_ids);
+        }
+
+        Self {
+            index: RwLock::new(index),
+        }
+    }
+
+    pub fn override_posting_list(&self, term: &str, point_ids: Vec<u64>) {
+        let mut index = self.index.write().unwrap();
+        index.insert(term.to_string(), point_ids);
+    }
+
+    pub fn query(&self, term: &str, limit: Option<usize>) -> Vec<u64> {
+        match self.index.read().unwrap().get(term) {
+            Some(results) => match limit {
+                Some(limit) => results.iter().take(limit).cloned().collect(),
+                None => results.clone(),
+            },
+            None => Vec::new(),
+        }
+    }
+}

--- a/src/storage/segment/index/text.rs
+++ b/src/storage/segment/index/text.rs
@@ -10,7 +10,7 @@ pub struct TextIndex(sled::Tree);
 
 // Full text search index implementation with posting lists
 impl TextIndex {
-    pub fn upsert(&self, point_id: u64, text: &String) -> Result<(), sled::Error> {
+    pub fn upsert(&self, point_id: u64, text: &str) -> Result<(), sled::Error> {
         // TODO: Add stop words, stemming, etc based on language
         // We need to tokenize the text into terms
         let terms: Vec<&str> = text.split_whitespace().collect();
@@ -22,7 +22,7 @@ impl TextIndex {
 
             let mut point_ids: Vec<u64> = self
                 .0
-                .get(&term_key)?
+                .get(term_key)?
                 .map(|data| {
                     // Decode existing point IDs for this term
                     // Todo: Apply delta encoding??
@@ -43,7 +43,7 @@ impl TextIndex {
                 )))
             })?;
 
-            self.0.insert(&term_key, encoded_ids).map_err(|e| {
+            self.0.insert(term_key, encoded_ids).map_err(|e| {
                 sled::Error::Io(std::io::Error::other(format!(
                     "Failed to insert into text index tree: {e}"
                 )))
@@ -64,7 +64,7 @@ impl FieldIndexTrait for TextIndex {
 
     fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error> {
         match value {
-            Value::String(text) => self.upsert(point_id, text),
+            Value::String(text) => self.upsert(point_id, text.as_str()),
             _ => Err(sled::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("{value} is not a valid string value"),
@@ -90,7 +90,7 @@ impl FieldIndexTrait for TextIndex {
 
         let point_ids: Vec<u64> = self
             .0
-            .get(&term_key)?
+            .get(term_key)?
             .map(|data| {
                 // Decode existing point IDs for this term
                 decoded_point_ids(&data)

--- a/src/storage/segment/mod.rs
+++ b/src/storage/segment/mod.rs
@@ -51,6 +51,7 @@ impl Segment {
         })
     }
 
+    // Rename path to segment_path
     pub fn load(path: &PathBuf) -> Result<Self, StorageError> {
         if !path.exists() {
             return Err(StorageError::ServiceError(format!(
@@ -70,6 +71,7 @@ impl Segment {
 
     /// Insert a batch of points into the segment
     pub fn insert_points(&self, points: &[Point]) -> Result<(), StorageError> {
+        // Todo: Batch insert with parallel threads?
         for point in points {
             let key = point.id.encode()?;
             let value = point.encode_payload()?;

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -224,9 +224,9 @@ pub async fn upsert_points(
             .map(|i| Point {
                 id: i,
                 payload: json!({
-                    "text": format!("Point {}", i),
+                    "description": format!("Point {}", i),
+                    "price": i as i64 * 10,
                     "timestamp": batch_ts.to_rfc3339(),
-                    "description": i as i64 * 10,
                 }),
             })
             .collect();

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -74,7 +74,7 @@ pub async fn create_collection(
         payload_schema["price"] = json!("int");
     }
     if !skip_text_index {
-        payload_schema["text"] = json!("text");
+        payload_schema["description"] = json!("text");
     }
 
     let res = client
@@ -226,7 +226,7 @@ pub async fn upsert_points(
                 payload: json!({
                     "text": format!("Point {}", i),
                     "timestamp": batch_ts.to_rfc3339(),
-                    "price": i as i64 * 10,
+                    "description": i as i64 * 10,
                 }),
             })
             .collect();

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -61,6 +61,7 @@ pub async fn create_collection(
     url: &Uri,
     collection_name: &str,
     skip_int_index: bool,
+    skip_text_index: bool,
     wait: bool,
 ) -> Result<ApiSuccessResponse<bool>, SmolBenchError> {
     // First ensure that consensus is started
@@ -68,13 +69,13 @@ pub async fn create_collection(
 
     let client = reqwest::Client::new();
 
-    let payload_schema = if skip_int_index {
-        json!({})
-    } else {
-        json!({
-            "price": "int"
-        })
-    };
+    let mut payload_schema = json!({});
+    if !skip_int_index {
+        payload_schema["price"] = json!("int");
+    }
+    if !skip_text_index {
+        payload_schema["text"] = json!("text");
+    }
 
     let res = client
         .put(format!("{url}/collections/{collection_name}"))

--- a/tools/smolbench/src/args.rs
+++ b/tools/smolbench/src/args.rs
@@ -59,8 +59,9 @@ pub struct Args {
     #[clap(long, default_value = "false")]
     pub skip_int_index: bool,
 
+    // ToDo: Remove this flag once text index is faster or decoupled
     /// Use text index for payload
-    #[clap(long, default_value = "false")]
+    #[clap(long, default_value = "true")]
     pub skip_text_index: bool,
 
     /// Use if you don't want to upsert points by default

--- a/tools/smolbench/src/args.rs
+++ b/tools/smolbench/src/args.rs
@@ -59,6 +59,10 @@ pub struct Args {
     #[clap(long, default_value = "false")]
     pub skip_int_index: bool,
 
+    /// Use text index for payload
+    #[clap(long, default_value = "false")]
+    pub skip_text_index: bool,
+
     /// Use if you don't want to upsert points by default
     #[clap(long, default_value = "false")]
     pub skip_upsert: bool,

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -121,6 +121,7 @@ async fn main() -> Result<(), SmolBenchError> {
                 apis::query_points(
                     &args.uri,
                     &args.collection_name,
+                    // ToDo: Benchmark with multiple filters at once
                     json!({
                         "filter": {
                             "key": "price",

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -40,8 +40,14 @@ async fn main() -> Result<(), SmolBenchError> {
                     args.collection_name
                 );
                 delete_collection(&args.uri, &args.collection_name, true).await?;
-                match create_collection(&args.uri, &args.collection_name, args.skip_int_index, true)
-                    .await
+                match create_collection(
+                    &args.uri,
+                    &args.collection_name,
+                    args.skip_int_index,
+                    args.skip_text_index,
+                    true,
+                )
+                .await
                 {
                     Ok(_) => println!("Collection created successfully."),
                     Err(e) => return Err(SmolBenchError::CreateCollectionError(e.to_string()))?,
@@ -52,8 +58,14 @@ async fn main() -> Result<(), SmolBenchError> {
                 "Collection '{}' does not exist, creating it",
                 args.collection_name
             );
-            match create_collection(&args.uri, &args.collection_name, args.skip_int_index, true)
-                .await
+            match create_collection(
+                &args.uri,
+                &args.collection_name,
+                args.skip_int_index,
+                args.skip_text_index,
+                true,
+            )
+            .await
             {
                 Ok(_) => println!("Collection created successfully."),
                 Err(e) => return Err(SmolBenchError::CreateCollectionError(e.to_string()))?,
@@ -114,7 +126,8 @@ async fn main() -> Result<(), SmolBenchError> {
                             "key": "price",
                             "value": format!("{}", price_gte * 10),
                             "op": "gte",
-                        }
+                        },
+                        "limit": 100,
                     }),
                 )
             })

--- a/tools/smolbench/src/tests/mod.rs
+++ b/tools/smolbench/src/tests/mod.rs
@@ -17,7 +17,7 @@ async fn test_smoldb_consecutive_writes() -> Result<(), crate::error::SmolBenchE
     let delay = None;
 
     let create_response =
-        crate::apis::create_collection(&uri, &collection_name, false, true).await?;
+        crate::apis::create_collection(&uri, &collection_name, false, false, true).await?;
 
     println!("Result: {}", &create_response.result);
     assert!(create_response.result);


### PR DESCRIPTION
Search is here. Let's gooo! This PR does the following:
- Introduce new `TextIndex` that naively implements lexical search using posting lists by reading/writing to disk
- Move out `IntegerIndex` into dedicated file. Tried to abstract out `FieldIndexTrait` (WIP)
- Add param to index text field by default in `smolbench`

```http
// Setup schema in collection config
PUT /collections/benchmark
{
  "params": "...",
  "payload_schema": { "description": "text", "price": "int" }
}

// Upsert points with description field

// Query like this:
POST /collections/benchmark/query
{
  "filter": {
    "key": "description",
    "value": "foo",
    "op": "eq" // Will drop/refactor soon, but required for now
  },
  "limit": 10
}

// Response:
{
  "result": {
    "points": [
      {
        "id": 0,
        "payload": {
          "price": 0,
          "description": "something foo 123",
          "timestamp": "2025-12-16T18:31:25.974421521+00:00"
        }
      }
    ]
  },
  "time": 0.020761092
}
```

## ToDo:
- [ ] Count term frequency and implement BM25
- [ ] Decouple upserts and indexing. Otherwise upserts become extremely slow as data grows in size.