### PR TITLE
Improve query perf with in-memory integer index

### DIFF
--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -34,6 +34,7 @@ pub fn single_text_query(c: &mut Criterion) {
         )
         .await
     });
+
     let collection_arc = Arc::new(collection);
 
     let query = Query {

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -34,7 +34,6 @@ pub fn single_text_query(c: &mut Criterion) {
         )
         .await
     });
-
     let collection_arc = Arc::new(collection);
 
     let query = Query {

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,3 +48,4 @@ impl From<tonic::Status> for CollectionError {
 }
 
 pub type CollectionResult<T> = Result<T, CollectionError>;
+pub type StorageResult<T> = Result<T, StorageError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn setup_logging() -> GlobalLoggerGuard {
     let logger = slog::Logger::root(drain, o!());
 
     let logger_guard = slog_scope::set_global_logger(logger);
-    slog_stdlog::init_with_level(log::Level::Info).unwrap();
+    slog_stdlog::init_with_level(log::Level::Debug).unwrap();
 
     logger_guard
 }

--- a/src/storage/segment/index/integer.rs
+++ b/src/storage/segment/index/integer.rs
@@ -18,8 +18,9 @@ pub struct IntegerIndex {
     tree: sled::Tree,
     // /// In-memory index copy for fast lookups
     in_memory: InMemoryIntegerIndex,
-    // Whether to query the disk index or the in-memory index
-    query_with_disk: bool,
+    // Whether to query the on-disk index or the in-memory index
+    // If yes, writes will update both in-memory and on-disk index
+    use_in_memory: bool,
 }
 
 impl IntegerIndex {
@@ -33,7 +34,7 @@ impl IntegerIndex {
         Ok(Self {
             tree,
             in_memory,
-            query_with_disk: false,
+            use_in_memory: true,
         })
     }
 
@@ -64,8 +65,9 @@ impl IntegerIndex {
             StorageError::ServiceError(format!("Failed to insert into index tree: {e}"))
         })?;
 
-        // Now update the in-memory index
-        self.in_memory.insert(value, point_ids)?;
+        if self.use_in_memory {
+            self.in_memory.insert(value, point_ids)?;
+        }
 
         Ok(())
     }
@@ -76,7 +78,7 @@ impl IntegerIndex {
         operation: &FilterOperator,
         limit: Option<usize>,
     ) -> StorageResult<Vec<PointId>> {
-        if !self.query_with_disk {
+        if self.use_in_memory {
             return self.in_memory.query(value, operation, limit);
         };
 

--- a/src/storage/segment/index/integer.rs
+++ b/src/storage/segment/index/integer.rs
@@ -1,32 +1,48 @@
 use serde_json::Value;
 use sled::Db;
-use std::ops::Bound;
+use std::{collections::BTreeMap, ops::Bound, sync::RwLock};
 
+use crate::error::{StorageError, StorageResult};
 use crate::storage::{
     index::{
         filter::FilterOperator,
-        payload_index::{decoded_point_ids, encoded_integer_value, encoded_point_ids},
+        payload_index::{decoded_point_ids, encoded_integer_value, decoded_integer_value, encoded_point_ids},
     },
     segment::PointId,
 };
 
-pub struct IntegerIndex(sled::Tree);
+pub struct IntegerIndex {
+    // For persistent storage
+    tree: sled::Tree,
+    // /// In-memory index copy for fast lookups
+    in_memory: InMemoryIntegerIndex,
+    // Whether to query the disk index or the in-memory index
+    query_with_disk: bool,
+}
 
 impl IntegerIndex {
-    pub fn open(db: &Db, name: &str) -> Self {
+    pub fn open(db: &Db, name: &str) -> StorageResult<Self> {
         let tree = db
             .open_tree(format!("{name}_numeric_index"))
             .expect("Failed to open sled tree");
-        Self(tree)
+
+        let in_memory = InMemoryIntegerIndex::new(&tree)?;
+
+        Ok(Self {
+            tree,
+            in_memory,
+            query_with_disk: false,
+        })
     }
 
-    pub fn upsert(&self, point_id: u64, value: i64) -> Result<(), sled::Error> {
+    /// todo: Upserting should also remove the point id from the index?
+    pub fn upsert(&self, point_id: u64, value: i64) -> StorageResult<()> {
         // In numeric tree, the point value becomes tree's key, and the point ID is part of a list of values.
         let tree_key = encoded_integer_value(value);
 
         // Fetch existing point IDs for this value
         let mut point_ids: Vec<u64> = self
-            .0
+            .tree
             .get(&tree_key)?
             .map(|data| {
                 decoded_point_ids(&data)
@@ -39,17 +55,14 @@ impl IntegerIndex {
         point_ids.sort();
 
         // Store back
-        let encoded_ids = encoded_point_ids(&point_ids).map_err(|e| {
-            sled::Error::Io(std::io::Error::other(format!(
-                "Failed to encode point IDs: {e}"
-            )))
+        let encoded_ids = encoded_point_ids(&point_ids)?;
+
+        self.tree.insert(&tree_key, encoded_ids).map_err(|e| {
+            StorageError::ServiceError(format!("Failed to insert into index tree: {e}"))
         })?;
 
-        self.0.insert(&tree_key, encoded_ids).map_err(|e| {
-            sled::Error::Io(std::io::Error::other(format!(
-                "Failed to insert into index tree: {e}"
-            )))
-        })?;
+        // Now update the in-memory index
+        self.in_memory.insert(value, point_ids)?;
 
         Ok(())
     }
@@ -59,7 +72,11 @@ impl IntegerIndex {
         value: i64,
         operation: &FilterOperator,
         limit: Option<usize>,
-    ) -> Result<Vec<PointId>, sled::Error> {
+    ) -> StorageResult<Vec<PointId>> {
+        if !self.query_with_disk {
+            return self.in_memory.query(value, operation, limit);
+        };
+
         let mut results = Vec::new();
 
         let value = encoded_integer_value(value);
@@ -72,7 +89,7 @@ impl IntegerIndex {
             FilterOperator::Eq => (Bound::Included(value.clone()), Bound::Included(value)),
         };
 
-        for item in self.0.range(bounds) {
+        for item in self.tree.range(bounds) {
             let (_gte_value, encoded_point_ids) = item?;
             let point_ids = decoded_point_ids(&encoded_point_ids).map_err(|e| {
                 sled::Error::Io(std::io::Error::other(format!("Failed to decode: {e}")))
@@ -90,16 +107,64 @@ impl IntegerIndex {
         Ok(results.into_iter().map(PointId::Id).collect())
     }
 
-    pub fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error> {
+    pub fn add_point(&self, point_id: u64, value: &Value) -> StorageResult<()> {
         match value {
             Value::Number(num) if num.is_i64() => {
                 let num_value = num.as_i64().unwrap();
                 self.upsert(point_id, num_value)
             }
-            _ => Err(sled::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("{value} is not a valid i64 value"),
+            _ => Err(StorageError::BadInput(format!(
+                "{value} is not a valid i64 value",
             ))),
         }
+    }
+}
+
+struct InMemoryIntegerIndex {
+    /// I can get rid of these locks if I introduce immutable segments
+    index: RwLock<BTreeMap<i64, Vec<u64>>>,
+}
+
+impl InMemoryIntegerIndex {
+    // Load in-memory index from disk
+    pub fn new(tree: &sled::Tree) -> StorageResult<Self> {
+        log::debug!("Loading in-memory integer index from disk");
+        let mut index = BTreeMap::new();
+        for item in tree.iter() {
+            let (key, value) = item?;
+            let integer_value = decoded_integer_value(&key);
+            let point_ids = decoded_point_ids(&value)?;
+            index.insert(integer_value, point_ids);
+        }
+
+        Ok(Self {
+            index: RwLock::new(index),
+        })
+    }
+
+    pub fn insert(&self, value: i64, point_ids: Vec<u64>) -> StorageResult<()> {
+        self.index
+            .write()
+            .map_err(|e| {
+                StorageError::ServiceError(format!("Failed to write to in-memory index: {e}"))
+            })?
+            .insert(value, point_ids);
+        Ok(())
+    }
+
+    pub fn query(
+        &self,
+        _value: i64,
+        _operation: &FilterOperator,
+        _limit: Option<usize>,
+    ) -> StorageResult<Vec<PointId>> {
+        // Query the in-memory index same as IntegerIndex::query to support all operations
+        let _guard = self.index.read().map_err(|e| {
+            StorageError::ServiceError(format!("Failed to read from in-memory index: {e}"))
+        })?;
+
+        // Todo: Implement query logic based on the operation
+
+        Ok(Vec::new())
     }
 }

--- a/src/storage/segment/index/integer.rs
+++ b/src/storage/segment/index/integer.rs
@@ -36,6 +36,7 @@ impl IntegerIndex {
     }
 
     /// todo: Upserting should also remove the point id from the index?
+    /// these should be decoupled from upsert so we can batch them
     pub fn upsert(&self, point_id: u64, value: i64) -> StorageResult<()> {
         // In numeric tree, the point value becomes tree's key, and the point ID is part of a list of values.
         let tree_key = encoded_integer_value(value);
@@ -90,7 +91,7 @@ impl IntegerIndex {
         };
 
         for item in self.tree.range(bounds) {
-            let (_gte_value, encoded_point_ids) = item?;
+            let (_integer_value, encoded_point_ids) = item?;
             let point_ids = decoded_point_ids(&encoded_point_ids).map_err(|e| {
                 sled::Error::Io(std::io::Error::other(format!("Failed to decode: {e}")))
             })?;
@@ -154,17 +155,36 @@ impl InMemoryIntegerIndex {
 
     pub fn query(
         &self,
-        _value: i64,
-        _operation: &FilterOperator,
-        _limit: Option<usize>,
+        value: i64,
+        operation: &FilterOperator,
+        limit: Option<usize>,
     ) -> StorageResult<Vec<PointId>> {
-        // Query the in-memory index same as IntegerIndex::query to support all operations
-        let _guard = self.index.read().map_err(|e| {
+        let index_guard = self.index.read().map_err(|e| {
             StorageError::ServiceError(format!("Failed to read from in-memory index: {e}"))
         })?;
 
-        // Todo: Implement query logic based on the operation
+        // todo: Convert into a generic that works with any type
+        let bounds = match operation {
+            FilterOperator::Gte => (Bound::Included(value), Bound::Unbounded),
+            FilterOperator::Gt => (Bound::Excluded(value), Bound::Unbounded),
+            FilterOperator::Lt => (Bound::Unbounded, Bound::Excluded(value)),
+            FilterOperator::Lte => (Bound::Unbounded, Bound::Included(value)),
+            FilterOperator::Eq => (Bound::Included(value.clone()), Bound::Included(value)),
+        };
 
-        Ok(Vec::new())
+        let mut results = Vec::new();
+
+        for (_int_value, point_ids) in index_guard.range(bounds) {
+            results.extend_from_slice(&point_ids);
+
+            if let Some(limit) = limit {
+                if results.len() >= limit {
+                    results.truncate(limit);
+                    break;
+                }
+            }
+        }
+
+        Ok(results.into_iter().map(PointId::Id).collect())
     }
 }

--- a/src/storage/segment/index/integer.rs
+++ b/src/storage/segment/index/integer.rs
@@ -169,13 +169,13 @@ impl InMemoryIntegerIndex {
             FilterOperator::Gt => (Bound::Excluded(value), Bound::Unbounded),
             FilterOperator::Lt => (Bound::Unbounded, Bound::Excluded(value)),
             FilterOperator::Lte => (Bound::Unbounded, Bound::Included(value)),
-            FilterOperator::Eq => (Bound::Included(value.clone()), Bound::Included(value)),
+            FilterOperator::Eq => (Bound::Included(value), Bound::Included(value)),
         };
 
         let mut results = Vec::new();
 
         for (_int_value, point_ids) in index_guard.range(bounds) {
-            results.extend_from_slice(&point_ids);
+            results.extend_from_slice(point_ids);
 
             if let Some(limit) = limit {
                 if results.len() >= limit {

--- a/src/storage/segment/index/integer.rs
+++ b/src/storage/segment/index/integer.rs
@@ -6,7 +6,9 @@ use crate::error::{StorageError, StorageResult};
 use crate::storage::{
     index::{
         filter::FilterOperator,
-        payload_index::{decoded_point_ids, encoded_integer_value, decoded_integer_value, encoded_point_ids},
+        payload_index::{
+            decoded_integer_value, decoded_point_ids, encoded_integer_value, encoded_point_ids,
+        },
     },
     segment::PointId,
 };

--- a/src/storage/segment/index/integer.rs
+++ b/src/storage/segment/index/integer.rs
@@ -17,25 +17,25 @@ pub struct IntegerIndex {
     // For persistent storage
     tree: sled::Tree,
     // /// In-memory index copy for fast lookups
-    in_memory: InMemoryIntegerIndex,
-    // Whether to query the on-disk index or the in-memory index
-    // If yes, writes will update both in-memory and on-disk index
-    use_in_memory: bool,
+    in_memory: Option<InMemoryIntegerIndex>,
 }
 
 impl IntegerIndex {
-    pub fn open(db: &Db, name: &str) -> StorageResult<Self> {
+    /// Note for `use_in_memory`:
+    /// Whether to query the on-disk index or the in-memory index
+    /// If yes, writes will update both in-memory and on-disk index
+    pub fn open(db: &Db, name: &str, use_in_memory: bool) -> StorageResult<Self> {
         let tree = db
             .open_tree(format!("{name}_numeric_index"))
             .expect("Failed to open sled tree");
 
-        let in_memory = InMemoryIntegerIndex::new(&tree)?;
+        let in_memory = if use_in_memory {
+            Some(InMemoryIntegerIndex::new(&tree)?)
+        } else {
+            None
+        };
 
-        Ok(Self {
-            tree,
-            in_memory,
-            use_in_memory: true,
-        })
+        Ok(Self { tree, in_memory })
     }
 
     /// todo: Upserting should also remove the point id from the index?
@@ -65,8 +65,8 @@ impl IntegerIndex {
             StorageError::ServiceError(format!("Failed to insert into index tree: {e}"))
         })?;
 
-        if self.use_in_memory {
-            self.in_memory.insert(value, point_ids)?;
+        if let Some(in_memory) = &self.in_memory {
+            in_memory.insert(value, point_ids)?;
         }
 
         Ok(())
@@ -78,8 +78,8 @@ impl IntegerIndex {
         operation: &FilterOperator,
         limit: Option<usize>,
     ) -> StorageResult<Vec<PointId>> {
-        if self.use_in_memory {
-            return self.in_memory.query(value, operation, limit);
+        if let Some(in_memory) = &self.in_memory {
+            return in_memory.query(value, operation, limit);
         };
 
         let mut results = Vec::new();

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -66,13 +66,17 @@ impl FieldIndexTrait<&Value> for FieldIndex {
     fn add_point(&self, point_id: u64, value: &Value) -> StorageResult<()> {
         match self {
             FieldIndex::Int(index) => index.add_point(point_id, value),
-            FieldIndex::Null => Err(StorageError::BadInput("Null index is not supported yet".to_string())),
+            FieldIndex::Null => Err(StorageError::BadInput(
+                "Null index is not supported yet".to_string(),
+            )),
             FieldIndex::Text(index) => index.add_point(point_id, value),
         }
     }
 
     fn open(_db: &Db, _name: &str) -> StorageResult<Self> {
-        Err(StorageError::BadInput("Use specific index constructors like new_numeric or new_text".to_string()))
+        Err(StorageError::BadInput(
+            "Use specific index constructors like new_numeric or new_text".to_string(),
+        ))
     }
 
     fn query(
@@ -84,17 +88,23 @@ impl FieldIndexTrait<&Value> for FieldIndex {
         let results = match self {
             FieldIndex::Int(int_index) => {
                 let value = value.as_i64().ok_or_else(|| {
-                    StorageError::BadInput(format!("Integer index query value must be an integer. Found {value}"))
+                    StorageError::BadInput(format!(
+                        "Integer index query value must be an integer. Found {value}"
+                    ))
                 })?;
 
                 int_index.query(value, operation, limit)?
             }
             FieldIndex::Null => {
-                return Err(StorageError::BadInput("Null index queries are not supported yet".to_string()));
+                return Err(StorageError::BadInput(
+                    "Null index queries are not supported yet".to_string(),
+                ));
             }
             FieldIndex::Text(t) => {
                 let value = value.as_str().ok_or_else(|| {
-                    StorageError::BadInput(format!("Text index query value must be a string. Found {value}"))
+                    StorageError::BadInput(format!(
+                        "Text index query value must be a string. Found {value}"
+                    ))
                 })?;
 
                 t.query(value, &FilterOperator::Eq, limit)?
@@ -123,7 +133,11 @@ impl PayloadIndex {
                 serde_json::from_slice(&value).expect("Failed to deserialize index config");
             let field_index = match index_config {
                 IndexConfig::Int => FieldIndex::new_numeric(db, &name),
-                IndexConfig::Null => return Err(StorageError::BadInput("Null index is not implemented yet".to_string())),
+                IndexConfig::Null => {
+                    return Err(StorageError::BadInput(
+                        "Null index is not implemented yet".to_string(),
+                    ))
+                }
                 IndexConfig::Text => FieldIndex::new_text(db, &name),
             }?;
             indices.insert(name, field_index);
@@ -150,7 +164,11 @@ impl PayloadIndex {
 
         let index = match index_config {
             IndexConfig::Int => FieldIndex::new_numeric(db, name)?,
-            IndexConfig::Null => return Err(StorageError::BadInput("Null index is not implemented yet".to_string())),
+            IndexConfig::Null => {
+                return Err(StorageError::BadInput(
+                    "Null index is not implemented yet".to_string(),
+                ))
+            }
             IndexConfig::Text => FieldIndex::new_text(db, name)?,
         };
 
@@ -202,7 +220,9 @@ impl PayloadIndex {
 
 pub trait FieldIndexTrait<DataType> {
     /// Create or load an index from the DB
-    fn open(db: &Db, name: &str) -> StorageResult<Self> where Self: Sized;
+    fn open(db: &Db, name: &str) -> StorageResult<Self>
+    where
+        Self: Sized;
     /// Add a point to the index
     fn add_point(&self, point_id: u64, value: &Value) -> StorageResult<()>;
     /// Query the index

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -9,7 +9,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sled::Db;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use utoipa::ToSchema;
 
 /// Converts the number into a big-endian value which is suitable for querying/storing in sled
@@ -100,14 +100,14 @@ impl FieldIndexTrait<&Value> for FieldIndex {
                     "Null index queries are not supported yet".to_string(),
                 ));
             }
-            FieldIndex::Text(t) => {
+            FieldIndex::Text(text_index) => {
                 let value = value.as_str().ok_or_else(|| {
                     StorageError::BadInput(format!(
                         "Text index query value must be a string. Found {value}"
                     ))
                 })?;
 
-                t.query(value, &FilterOperator::Eq, limit)?
+                text_index.query(value, &FilterOperator::Eq, limit)?
             }
         };
 
@@ -116,7 +116,7 @@ impl FieldIndexTrait<&Value> for FieldIndex {
 }
 
 pub struct PayloadIndex {
-    pub indices: HashMap<String, FieldIndex>,
+    pub indices: BTreeMap<String, FieldIndex>,
 }
 
 impl PayloadIndex {
@@ -125,7 +125,7 @@ impl PayloadIndex {
         let schema_tree = db
             .open_tree("schema")
             .expect("Failed to open segment schema tree");
-        let mut indices = HashMap::new();
+        let mut indices = BTreeMap::new();
         for item in schema_tree.iter() {
             let (key, value) = item.expect("Failed to read schema item");
             let name = String::from_utf8(key.to_vec()).expect("Invalid UTF-8 in key");
@@ -243,33 +243,44 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_payload_index() {
+    fn test_payload_index() -> StorageResult<()> {
         let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
         let db = sled::open(&tmp_dir).expect("Failed to open sled database");
-        let mut index = PayloadIndex::get_or_create(&db).unwrap();
+        let mut index = PayloadIndex::get_or_create(&db)?;
 
-        index.add_index(&db, "price", IndexConfig::Int).unwrap();
+        index.add_index(&db, "price", IndexConfig::Int)?;
+        index.add_index(&db, "description", IndexConfig::Text)?;
 
-        assert!(index.get_index_names().len() == 1);
-        assert!(index.indices.contains_key("price"));
+        assert_eq!(index.get_index_names(), ["description", "price"]);
 
         for i in 0..10 {
-            index
-                .upsert(&Point {
-                    id: PointId::Id(i),
-                    payload: json!({"price": i * 10}),
-                })
-                .unwrap();
+            index.upsert(&Point {
+                id: PointId::Id(i),
+                payload: json!({"price": i * 10, "description": format!("foo {i}")}),
+            })?;
         }
 
-        let field_index = index.indices.get("price").unwrap();
+        // Todo: Test on-disk and in-memory index separately
 
-        if let FieldIndex::Int(numeric_index) = field_index {
-            let results = numeric_index.query(40, &FilterOperator::Gte, None).unwrap();
+        if let Some(FieldIndex::Int(int_index)) = index.indices.get("price") {
+            let results = int_index.query(40, &FilterOperator::Gte, None)?;
             assert_eq!(results.len(), 6); // Points with ids 4, 5, 6, 7, 8, 9
             assert_eq!(results, (4..10).map(PointId::Id).collect::<Vec<_>>());
         } else {
             panic!("Expected NumericIndex");
         }
+
+        if let Some(FieldIndex::Text(text_index)) = index.indices.get("description") {
+            let results = text_index.query("4", &FilterOperator::Eq, None)?;
+            assert_eq!(results.len(), 1);
+            assert_eq!(results, vec![PointId::Id(4)]);
+
+            let results = text_index.query("missingTerm", &FilterOperator::Eq, None)?;
+            assert_eq!(results.len(), 0);
+        } else {
+            panic!("Expected TextIndex");
+        }
+
+        Ok(())
     }
 }

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -52,12 +52,12 @@ pub enum IndexConfig {
 
 impl FieldIndex {
     pub fn new_numeric(db: &Db, name: &str) -> StorageResult<Self> {
-        let index = IntegerIndex::open(db, name)?;
+        let index = IntegerIndex::open(db, name, true)?;
         Ok(FieldIndex::Int(index))
     }
 
     pub fn new_text(db: &Db, name: &str) -> StorageResult<Self> {
-        let index = TextIndex::open(db, name)?;
+        let index = TextIndex::open(db, name, true)?;
         Ok(FieldIndex::Text(index))
     }
 }
@@ -73,7 +73,7 @@ impl FieldIndexTrait<&Value> for FieldIndex {
         }
     }
 
-    fn open(_db: &Db, _name: &str) -> StorageResult<Self> {
+    fn open(_db: &Db, _name: &str, _use_in_memory: bool) -> StorageResult<Self> {
         Err(StorageError::BadInput(
             "Use specific index constructors like new_numeric or new_text".to_string(),
         ))
@@ -220,7 +220,11 @@ impl PayloadIndex {
 
 pub trait FieldIndexTrait<DataType> {
     /// Create or load an index from the DB
-    fn open(db: &Db, name: &str) -> StorageResult<Self>
+    ///
+    /// Note for `use_in_memory`:
+    /// Whether to query the on-disk index or the in-memory index
+    /// If yes, writes will update both in-memory and on-disk index
+    fn open(db: &Db, name: &str, use_in_memory: bool) -> StorageResult<Self>
     where
         Self: Sized;
     /// Add a point to the index

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -1,5 +1,6 @@
 use crate::{
     api::points::Query,
+    error::{StorageError, StorageResult},
     storage::{
         index::{filter::FilterOperator, integer::IntegerIndex, text::TextIndex},
         segment::{Point, PointId},
@@ -17,12 +18,22 @@ pub fn encoded_integer_value(n: i64) -> Vec<u8> {
     n.to_be_bytes().to_vec()
 }
 
-pub fn encoded_point_ids(point_ids: &[u64]) -> Result<Vec<u8>, bincode::error::EncodeError> {
-    bincode::encode_to_vec(point_ids, bincode::config::standard())
+/// Reverse of `encoded_integer_value`
+pub fn decoded_integer_value(data: &[u8]) -> i64 {
+    let mut buf = [0u8; 8]; // 8 bytes for i64
+    buf.copy_from_slice(data);
+    i64::from_be_bytes(buf)
 }
 
-pub fn decoded_point_ids(data: &[u8]) -> Result<Vec<u64>, bincode::error::DecodeError> {
-    bincode::decode_from_slice(data, bincode::config::standard()).map(|(ids, _)| ids)
+pub fn encoded_point_ids(point_ids: &[u64]) -> StorageResult<Vec<u8>> {
+    bincode::encode_to_vec(point_ids, bincode::config::standard())
+        .map_err(|e| StorageError::CodecError(format!("Failed to encode point IDs: {e}")))
+}
+
+pub fn decoded_point_ids(data: &[u8]) -> StorageResult<Vec<u64>> {
+    bincode::decode_from_slice(data, bincode::config::standard())
+        .map(|(ids, _)| ids)
+        .map_err(|e| StorageError::CodecError(format!("Failed to decode point IDs: {e}")))
 }
 
 pub enum FieldIndex {
@@ -40,28 +51,28 @@ pub enum IndexConfig {
 }
 
 impl FieldIndex {
-    pub fn new_numeric(db: &Db, name: &str) -> Self {
-        FieldIndex::Int(IntegerIndex::open(db, name))
+    pub fn new_numeric(db: &Db, name: &str) -> StorageResult<Self> {
+        let index = IntegerIndex::open(db, name)?;
+        Ok(FieldIndex::Int(index))
     }
 
-    pub fn new_text(db: &Db, name: &str) -> Self {
-        FieldIndex::Text(TextIndex::open(db, name))
+    pub fn new_text(db: &Db, name: &str) -> StorageResult<Self> {
+        let index = TextIndex::open(db, name)?;
+        Ok(FieldIndex::Text(index))
     }
 }
 
 impl FieldIndexTrait<&Value> for FieldIndex {
-    fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error> {
+    fn add_point(&self, point_id: u64, value: &Value) -> StorageResult<()> {
         match self {
             FieldIndex::Int(index) => index.add_point(point_id, value),
-            FieldIndex::Null => {
-                unimplemented!("Null index is not implemented yet");
-            }
+            FieldIndex::Null => Err(StorageError::BadInput("Null index is not supported yet".to_string())),
             FieldIndex::Text(index) => index.add_point(point_id, value),
         }
     }
 
-    fn open(_db: &Db, _name: &str) -> Self {
-        unimplemented!("Use specific index constructors like new_numeric or new_text");
+    fn open(_db: &Db, _name: &str) -> StorageResult<Self> {
+        Err(StorageError::BadInput("Use specific index constructors like new_numeric or new_text".to_string()))
     }
 
     fn query(
@@ -69,27 +80,21 @@ impl FieldIndexTrait<&Value> for FieldIndex {
         value: &Value,
         operation: &FilterOperator,
         limit: Option<usize>,
-    ) -> Result<Vec<PointId>, sled::Error> {
+    ) -> StorageResult<Vec<PointId>> {
         let results = match self {
             FieldIndex::Int(int_index) => {
                 let value = value.as_i64().ok_or_else(|| {
-                    sled::Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        format!("Integer index query value must be an integer. Found {value}"),
-                    ))
+                    StorageError::BadInput(format!("Integer index query value must be an integer. Found {value}"))
                 })?;
 
                 int_index.query(value, operation, limit)?
             }
             FieldIndex::Null => {
-                unimplemented!("Null index queries are not implemented yet");
+                return Err(StorageError::BadInput("Null index queries are not supported yet".to_string()));
             }
             FieldIndex::Text(t) => {
                 let value = value.as_str().ok_or_else(|| {
-                    sled::Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        format!("Text index query value must be a string. Found {value}"),
-                    ))
+                    StorageError::BadInput(format!("Text index query value must be a string. Found {value}"))
                 })?;
 
                 t.query(value, &FilterOperator::Eq, limit)?
@@ -106,7 +111,7 @@ pub struct PayloadIndex {
 
 impl PayloadIndex {
     /// Read from the database to get existing indices and their types. If no indices are found, create a new empty index.
-    pub fn get_or_create(db: &Db) -> Self {
+    pub fn get_or_create(db: &Db) -> StorageResult<Self> {
         let schema_tree = db
             .open_tree("schema")
             .expect("Failed to open segment schema tree");
@@ -118,13 +123,13 @@ impl PayloadIndex {
                 serde_json::from_slice(&value).expect("Failed to deserialize index config");
             let field_index = match index_config {
                 IndexConfig::Int => FieldIndex::new_numeric(db, &name),
-                IndexConfig::Null => FieldIndex::Null,
+                IndexConfig::Null => return Err(StorageError::BadInput("Null index is not implemented yet".to_string())),
                 IndexConfig::Text => FieldIndex::new_text(db, &name),
-            };
+            }?;
             indices.insert(name, field_index);
         }
 
-        Self { indices }
+        Ok(Self { indices })
     }
 
     pub fn get_index_names(&self) -> Vec<&str> {
@@ -136,18 +141,17 @@ impl PayloadIndex {
         db: &Db,
         name: &str,
         index_config: IndexConfig,
-    ) -> Result<(), sled::Error> {
+    ) -> StorageResult<()> {
         if self.indices.contains_key(name) {
-            return Err(sled::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::AlreadyExists,
-                format!("Index with name '{name}' already exists"),
+            return Err(StorageError::BadInput(format!(
+                "Index with name '{name}' already exists",
             )));
         }
 
         let index = match index_config {
-            IndexConfig::Int => FieldIndex::new_numeric(db, name),
-            IndexConfig::Null => unimplemented!("Null index is not implemented yet"),
-            IndexConfig::Text => FieldIndex::new_text(db, name),
+            IndexConfig::Int => FieldIndex::new_numeric(db, name)?,
+            IndexConfig::Null => return Err(StorageError::BadInput("Null index is not implemented yet".to_string())),
+            IndexConfig::Text => FieldIndex::new_text(db, name)?,
         };
 
         let index_config_str =
@@ -166,13 +170,10 @@ impl PayloadIndex {
 
     /// ToDo: Support updating existing points in the index. This would require removing old values and adding new ones.
     /// ToDo: Decoupling indexing from upserts. So that we can upsert fast and index in the background.
-    pub fn upsert(&self, point: &Point) -> Result<(), sled::Error> {
-        // todo: Use id tracker so that we can support different PointId types while being storage efficient.
+    // todo: Use id tracker so that we can support different PointId types while being storage efficient.
+    pub fn upsert(&self, point: &Point) -> StorageResult<()> {
         let PointId::Id(point_id) = point.id else {
-            return Err(sled::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Invalid PointId type: Only u64 point ID is supported for payload indexing (for now)",
-            )));
+            return Err(StorageError::BadInput("Invalid PointId type: Only u64 point ID is supported for payload indexing (for now)".to_string()));
         };
 
         for (index_key, index_tree) in &self.indices {
@@ -185,13 +186,10 @@ impl PayloadIndex {
 
     // Todo: Support deleting points from the index in case of update or deletes
 
-    pub fn query(&self, query: Query) -> Result<Vec<PointId>, sled::Error> {
+    pub fn query(&self, query: Query) -> StorageResult<Vec<PointId>> {
         // ToDo: Should allow querying for un-indexed fields to demonstrate/benchmark difference
         let index = self.indices.get(&query.filter.key).ok_or_else(|| {
-            sled::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("No index found for key '{}'", query.filter.key),
-            ))
+            StorageError::BadInput(format!("No index found for key '{}'", query.filter.key))
         })?;
 
         // Todo: Support combining results from multiple indices for complex queries
@@ -204,21 +202,23 @@ impl PayloadIndex {
 
 pub trait FieldIndexTrait<DataType> {
     /// Create or load an index from the DB
-    fn open(db: &Db, name: &str) -> Self;
+    fn open(db: &Db, name: &str) -> StorageResult<Self> where Self: Sized;
     /// Add a point to the index
-    fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error>;
+    fn add_point(&self, point_id: u64, value: &Value) -> StorageResult<()>;
     /// Query the index
     fn query(
         &self,
         value: DataType,
         operation: &FilterOperator,
         limit: Option<usize>,
-    ) -> Result<Vec<PointId>, sled::Error>;
+    ) -> StorageResult<Vec<PointId>>;
 }
 
 #[cfg(test)]
 mod test {
     use serde_json::json;
+
+    use crate::storage::index::filter::FilterOperator;
 
     use super::*;
 
@@ -226,7 +226,7 @@ mod test {
     fn test_payload_index() {
         let tmp_dir = tempfile::tempdir().expect("Failed to create temp dir");
         let db = sled::open(&tmp_dir).expect("Failed to open sled database");
-        let mut index = PayloadIndex::get_or_create(&db);
+        let mut index = PayloadIndex::get_or_create(&db).unwrap();
 
         index.add_index(&db, "price", IndexConfig::Int).unwrap();
 

--- a/src/storage/segment/index/text.rs
+++ b/src/storage/segment/index/text.rs
@@ -16,10 +16,7 @@ use crate::{
 
 pub struct TextIndex {
     db: sled::Tree,
-    in_memory_index: InMemoryTextIndex,
-    // Whether to query the on-disk index or the in-memory index
-    // If yes, writes will update both in-memory and on-disk index
-    use_in_memory: bool,
+    in_memory_index: Option<InMemoryTextIndex>,
 }
 
 // Full text search index implementation with posting lists
@@ -57,8 +54,8 @@ impl TextIndex {
                 StorageError::ServiceError(format!("Failed to insert into text index tree: {e}"))
             })?;
 
-            if self.use_in_memory {
-                self.in_memory_index.override_posting_list(term, point_ids);
+            if let Some(in_memory_index) = &self.in_memory_index {
+                in_memory_index.override_posting_list(term, point_ids);
             }
         }
 
@@ -67,15 +64,18 @@ impl TextIndex {
 }
 
 impl FieldIndexTrait<&str> for TextIndex {
-    fn open(db: &Db, name: &str) -> StorageResult<Self> {
+    fn open(db: &Db, name: &str, use_in_memory: bool) -> StorageResult<Self> {
         let tree = db.open_tree(format!("{name}_text_index"))?;
 
-        let in_memory_index = InMemoryTextIndex::new(db);
+        let in_memory_index = if use_in_memory {
+            Some(InMemoryTextIndex::new(db))
+        } else {
+            None
+        };
 
         Ok(Self {
             db: tree,
             in_memory_index,
-            use_in_memory: true,
         })
     }
 
@@ -94,9 +94,8 @@ impl FieldIndexTrait<&str> for TextIndex {
         _operation: &FilterOperator, // todo: Remove operation for text index?
         limit: Option<usize>,
     ) -> StorageResult<Vec<PointId>> {
-        if self.use_in_memory {
-            return Ok(self
-                .in_memory_index
+        if let Some(in_memory_index) = &self.in_memory_index {
+            return Ok(in_memory_index
                 .query(value, limit)
                 .into_iter()
                 .map(PointId::Id)

--- a/src/storage/segment/index/text.rs
+++ b/src/storage/segment/index/text.rs
@@ -17,6 +17,8 @@ use crate::{
 pub struct TextIndex {
     db: sled::Tree,
     in_memory_index: InMemoryTextIndex,
+    // Whether to query the on-disk index or the in-memory index
+    // If yes, writes will update both in-memory and on-disk index
     use_in_memory: bool,
 }
 
@@ -73,7 +75,7 @@ impl FieldIndexTrait<&str> for TextIndex {
         Ok(Self {
             db: tree,
             in_memory_index,
-            use_in_memory: false,
+            use_in_memory: true,
         })
     }
 

--- a/src/storage/segment/index/text.rs
+++ b/src/storage/segment/index/text.rs
@@ -3,13 +3,13 @@ use std::{collections::HashMap, sync::RwLock};
 use serde_json::Value;
 use sled::Db;
 
-use crate::storage::{
+use crate::{error::{StorageError, StorageResult}, storage::{
     index::{
         filter::FilterOperator,
-        payload_index::{decoded_point_ids, encoded_point_ids, FieldIndexTrait},
+        payload_index::{FieldIndexTrait, decoded_point_ids, encoded_point_ids},
     },
     segment::PointId,
-};
+}};
 
 pub struct TextIndex {
     db: sled::Tree,
@@ -19,7 +19,7 @@ pub struct TextIndex {
 
 // Full text search index implementation with posting lists
 impl TextIndex {
-    pub fn upsert(&self, point_id: u64, text: &str) -> Result<(), sled::Error> {
+    pub fn upsert(&self, point_id: u64, text: &str) -> StorageResult<()> {
         // TODO: Add stop words, stemming, etc based on language
         // We need to tokenize the text into terms
         let terms: Vec<&str> = text.split_whitespace().collect();
@@ -46,16 +46,10 @@ impl TextIndex {
             point_ids.sort();
 
             // Store back
-            let encoded_ids = encoded_point_ids(&point_ids).map_err(|e| {
-                sled::Error::Io(std::io::Error::other(format!(
-                    "Failed to encode point IDs for posting list: {e}"
-                )))
-            })?;
+            let encoded_ids = encoded_point_ids(&point_ids)?;
 
             self.db.insert(term_key, encoded_ids).map_err(|e| {
-                sled::Error::Io(std::io::Error::other(format!(
-                    "Failed to insert into text index tree: {e}"
-                )))
+                StorageError::ServiceError(format!("Failed to insert into text index tree: {e}"))
             })?;
 
             if self.use_in_memory {
@@ -68,27 +62,23 @@ impl TextIndex {
 }
 
 impl FieldIndexTrait<&str> for TextIndex {
-    fn open(db: &Db, name: &str) -> Self {
+    fn open(db: &Db, name: &str) -> StorageResult<Self> {
         let tree = db
-            .open_tree(format!("{name}_text_index"))
-            .expect("Failed to open sled tree");
+            .open_tree(format!("{name}_text_index"))?;
 
         let in_memory_index = InMemoryTextIndex::new(db);
 
-        Self {
+        Ok(Self {
             db: tree,
             in_memory_index,
             use_in_memory: false,
-        }
+        })
     }
 
-    fn add_point(&self, point_id: u64, value: &Value) -> Result<(), sled::Error> {
+    fn add_point(&self, point_id: u64, value: &Value) -> StorageResult<()> {
         match value {
             Value::String(text) => self.upsert(point_id, text.as_str()),
-            _ => Err(sled::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("{value} is not a valid string value"),
-            ))),
+            _ => Err(StorageError::BadInput(format!("{value} is not a valid string value"))),
         }
     }
 
@@ -97,7 +87,7 @@ impl FieldIndexTrait<&str> for TextIndex {
         value: &str,
         _operation: &FilterOperator, // todo: Remove operation for text index?
         limit: Option<usize>,
-    ) -> Result<Vec<PointId>, sled::Error> {
+    ) -> StorageResult<Vec<PointId>> {
         if self.use_in_memory {
             return Ok(self
                 .in_memory_index
@@ -110,15 +100,8 @@ impl FieldIndexTrait<&str> for TextIndex {
         let mut results = Vec::new();
         let query_key = value.as_bytes();
 
-        let point_ids: Vec<u64> = self
-            .db
-            .get(query_key)?
-            .map(|data| {
-                // Decode existing point IDs for this term
-                decoded_point_ids(&data)
-                    .unwrap_or_else(|e| panic!("Failed to decode point IDs from posting list: {e}"))
-            })
-            .unwrap_or_default();
+        // Decode existing point IDs for this term
+        let point_ids = decoded_point_ids(&self.db.get(query_key)?.unwrap_or_default())?;
 
         for point_id in point_ids {
             results.push(PointId::Id(point_id));

--- a/src/storage/segment/index/text.rs
+++ b/src/storage/segment/index/text.rs
@@ -104,8 +104,13 @@ impl FieldIndexTrait<&str> for TextIndex {
         let mut results = Vec::new();
         let query_key = value.as_bytes();
 
+        let Some(encoded_point_ids) = self.db.get(query_key)? else {
+            // No results found for this term
+            return Ok(Vec::new());
+        };
+
         // Decode existing point IDs for this term
-        let point_ids = decoded_point_ids(&self.db.get(query_key)?.unwrap_or_default())?;
+        let point_ids = decoded_point_ids(&encoded_point_ids)?;
 
         for point_id in point_ids {
             results.push(PointId::Id(point_id));

--- a/src/storage/segment/index/text.rs
+++ b/src/storage/segment/index/text.rs
@@ -3,13 +3,16 @@ use std::{collections::HashMap, sync::RwLock};
 use serde_json::Value;
 use sled::Db;
 
-use crate::{error::{StorageError, StorageResult}, storage::{
-    index::{
-        filter::FilterOperator,
-        payload_index::{FieldIndexTrait, decoded_point_ids, encoded_point_ids},
+use crate::{
+    error::{StorageError, StorageResult},
+    storage::{
+        index::{
+            filter::FilterOperator,
+            payload_index::{decoded_point_ids, encoded_point_ids, FieldIndexTrait},
+        },
+        segment::PointId,
     },
-    segment::PointId,
-}};
+};
 
 pub struct TextIndex {
     db: sled::Tree,
@@ -63,8 +66,7 @@ impl TextIndex {
 
 impl FieldIndexTrait<&str> for TextIndex {
     fn open(db: &Db, name: &str) -> StorageResult<Self> {
-        let tree = db
-            .open_tree(format!("{name}_text_index"))?;
+        let tree = db.open_tree(format!("{name}_text_index"))?;
 
         let in_memory_index = InMemoryTextIndex::new(db);
 
@@ -78,7 +80,9 @@ impl FieldIndexTrait<&str> for TextIndex {
     fn add_point(&self, point_id: u64, value: &Value) -> StorageResult<()> {
         match value {
             Value::String(text) => self.upsert(point_id, text.as_str()),
-            _ => Err(StorageError::BadInput(format!("{value} is not a valid string value"))),
+            _ => Err(StorageError::BadInput(format!(
+                "{value} is not a valid string value"
+            ))),
         }
     }
 

--- a/src/storage/segment/mod.rs
+++ b/src/storage/segment/mod.rs
@@ -3,7 +3,7 @@ pub mod point;
 
 use crate::{
     api::points::Query,
-    error::StorageError,
+    error::{StorageError, StorageResult},
     storage::index::payload_index::{IndexConfig, PayloadIndex},
 };
 use futures::StreamExt;
@@ -36,7 +36,7 @@ impl Segment {
             StorageError::ServiceError(format!("Failed to open segment database: {e}"))
         })?;
 
-        let mut payload_index = PayloadIndex::get_or_create(&db);
+        let mut payload_index = PayloadIndex::get_or_create(&db)?;
 
         for (index_name, index_config) in payload_schema {
             payload_index
@@ -51,8 +51,7 @@ impl Segment {
         })
     }
 
-    // Rename path to segment_path
-    pub fn load(path: &PathBuf) -> Result<Self, StorageError> {
+    pub fn load(path: &PathBuf) -> StorageResult<Self> {
         if !path.exists() {
             return Err(StorageError::ServiceError(format!(
                 "Segment path does not exist: {path:?}"
@@ -60,7 +59,7 @@ impl Segment {
         }
 
         let db = sled::open(path).expect("Failed to open segment database");
-        let payload_index = PayloadIndex::get_or_create(&db);
+        let payload_index = PayloadIndex::get_or_create(&db)?;
 
         Ok(Self {
             path: path.to_owned(),
@@ -70,8 +69,7 @@ impl Segment {
     }
 
     /// Insert a batch of points into the segment
-    pub fn insert_points(&self, points: &[Point]) -> Result<(), StorageError> {
-        // Todo: Batch insert with parallel threads?
+    pub fn insert_points(&self, points: &[Point]) -> StorageResult<()> {
         for point in points {
             let key = point.id.encode()?;
             let value = point.encode_payload()?;

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -109,9 +109,10 @@ async fn main() -> Result<(), SmolBenchError> {
 
     if !args.skip_query {
         let num_queries = (args.num_points as f32 * 0.01).max(100_f32) as u64;
+        let limit = 100;
         println!(
-            "Querying {} points with concurrency of {} from collection '{}' with price filter",
-            num_queries, args.concurrent_queries, args.collection_name,
+            "Querying {} points with concurrency of {} from collection '{}' with price filter and limit of {}",
+            num_queries, args.concurrent_queries, args.collection_name, limit,
         );
 
         let mut rnd = rand::rng();
@@ -128,7 +129,7 @@ async fn main() -> Result<(), SmolBenchError> {
                             "value": format!("{}", price_gte * 10),
                             "op": "gte",
                         },
-                        "limit": 100,
+                        "limit": limit,
                     }),
                 )
             })


### PR DESCRIPTION
This PR does the following:
- Introduce `InMemoryIntegerIndex` to complement `IntegerIndex` which maintains a copy of the content from disk. reads are answered by this while writes are applied to both.
- Extract out `IntegerIndex` into dedicated `integer.rs`

Extra stuff (could have done in different PRs, but okay):
- Print `debug` log level msgs by default
- Use `StorageError` and `StorageResult` across the segment instead of `sled:Error` which is often unrelated
- Update `smolbench` limit to be 100 instead of `None`
- `PayloadIndex` now uses `indices: BTreeMap<String, FieldIndex>`