### PR TITLE
Decouple indexing from inserts

### DIFF
--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -126,21 +126,23 @@ pub async fn create_collection_with_points(
     channel_service: Arc<ChannelService>,
     payload_schema: Option<BTreeMap<String, IndexConfig>>,
     points: Vec<Point>,
+    wait_for_indexing: bool,
 ) -> Collection {
     let collection =
         create_collection("test_collection", tempdir, channel_service, payload_schema).await;
     collection.upsert_points(points, true).await.unwrap();
 
-    // Wait for indexing to complete
-    let start_time = std::time::Instant::now();
-    loop {
-        let pending_indexing_count = collection.get_pending_indexing_count(None).await;
-        if pending_indexing_count > 0 {
-            eprintln!("Waiting for indexing to complete... {pending_indexing_count} points pending, elapsed: {:.2?}", start_time.elapsed());
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        } else {
-            eprintln!("Indexing completed! Elapsed: {:.2?}", start_time.elapsed());
-            break;
+    if wait_for_indexing {
+        let start_time = std::time::Instant::now();
+        loop {
+            let pending_indexing_count = collection.get_pending_indexing_count(None).await;
+            if pending_indexing_count > 0 {
+                eprintln!("Waiting for indexing to complete... {pending_indexing_count} points pending, elapsed: {:.2?}", start_time.elapsed());
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            } else {
+                eprintln!("Indexing completed! Elapsed: {:.2?}", start_time.elapsed());
+                break;
+            }
         }
     }
 

--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use std::{collections::BTreeMap, sync::Arc};
 
 use criterion::BenchmarkGroup;
@@ -125,6 +126,20 @@ pub async fn create_collection_with_points(
     let collection =
         create_collection("test_collection", tempdir, channel_service, payload_schema).await;
     collection.upsert_points(points, true).await.unwrap();
+
+    // Wait for indexing to complete
+    let start_time = std::time::Instant::now();
+    loop {
+        let pending_indexing_count = collection.get_pending_indexing_count(None).await;
+        if pending_indexing_count > 0 {
+            eprintln!("Waiting for indexing to complete... {pending_indexing_count} points pending, elapsed: {:.2?}", start_time.elapsed());
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        } else {
+            eprintln!("Indexing completed! Elapsed: {:.2?}", start_time.elapsed());
+            break;
+        }
+    }
+
     collection
 }
 

--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -26,6 +26,9 @@ pub const BATCH_SIZE: usize = 1000;
 pub const NUM_QUERIES: usize = 1000;
 pub const CONCURRENCY: usize = 16;
 
+pub const TEXT_FIELD: &str = "description";
+pub const INT_FIELD: &str = "price";
+
 /// Creates a new multi-threaded tokio runtime for benchmarks
 pub fn create_runtime() -> Runtime {
     tokio::runtime::Builder::new_multi_thread()
@@ -71,7 +74,7 @@ pub fn generate_points(num_points: u64) -> Vec<Point> {
     (0..num_points)
         .map(|id| Point {
             id: PointId::Id(id),
-            payload: json!({ "msg": format!("Hello world {}", id), "price": id as i64 * 10 }),
+            payload: json!({ TEXT_FIELD: format!("Hello world {}", id), INT_FIELD: id as i64 * 10 }),
         })
         .collect()
 }
@@ -83,7 +86,8 @@ pub fn generate_random_points(num_points: usize) -> Vec<Point> {
     (0..num_points)
         .map(|_| {
             let id = rand::random_range(0..NUM_POINTS);
-            let payload = json!({ "msg": format!("Hello world {}", id), "price": id as i64 * 10 });
+            let payload =
+                json!({ TEXT_FIELD: format!("Hello world {}", id), INT_FIELD: id as i64 * 10 });
             Point {
                 id: PointId::Id(id),
                 payload,
@@ -96,7 +100,7 @@ pub fn generate_random_points(num_points: usize) -> Vec<Point> {
 pub fn generate_int_queries(num_queries: usize) -> Vec<Query> {
     (0..num_queries)
         .map(|i| Query {
-            filter: QueryFilter::new("price", Value::from(i * 10), FilterOperator::Gte),
+            filter: QueryFilter::new(INT_FIELD, Value::from(i * 10), FilterOperator::Gte),
             limit: Some(10),
         })
         .collect::<Vec<_>>()
@@ -107,7 +111,7 @@ pub fn generate_text_queries(num_queries: usize) -> Vec<Query> {
     (0..num_queries)
         .map(|i| Query {
             filter: QueryFilter::new(
-                "text",
+                TEXT_FIELD,
                 Value::from(format!("Hello world {}", i)),
                 FilterOperator::Eq,
             ),

--- a/benches/collection/index.rs
+++ b/benches/collection/index.rs
@@ -15,27 +15,31 @@ pub fn int_indexing(c: &mut Criterion) {
     let point_ids: Vec<u64> = (0..num_points).collect();
     let values = generate_integer_values(num_points as usize);
 
-    group.bench_function("batch", |b| {
+    {
         let (db, _tempdir) = create_temp_db();
         let index = IntegerIndex::open(&db, "price", false).unwrap();
 
-        b.iter(|| {
-            // todo: Add batching when supported by integer index
-            for (point_id, value) in point_ids.iter().zip(values.iter()) {
-                index.upsert(*point_id, *value).unwrap();
-            }
+        group.bench_function("batch", |b| {
+            b.iter(|| {
+                // todo: Add batching when supported by integer index
+                for (point_id, value) in point_ids.iter().zip(values.iter()) {
+                    index.upsert(*point_id, *value).unwrap();
+                }
+            });
         });
-    });
+    }
 
-    group.bench_function("in_memory/batch", |b| {
+    {
         let (db, _tempdir) = create_temp_db();
         let index_with_in_mem = IntegerIndex::open(&db, "price", true).unwrap();
 
-        b.iter(|| {
-            // todo: Add batching when supported by integer index
-            for (point_id, value) in point_ids.iter().zip(values.iter()) {
-                index_with_in_mem.upsert(*point_id, *value).unwrap();
-            }
+        group.bench_function("in_memory/batch", |b| {
+            b.iter(|| {
+                // todo: Add batching when supported by integer index
+                for (point_id, value) in point_ids.iter().zip(values.iter()) {
+                    index_with_in_mem.upsert(*point_id, *value).unwrap();
+                }
+            });
         });
-    });
+    }
 }

--- a/benches/collection/query.rs
+++ b/benches/collection/query.rs
@@ -26,6 +26,7 @@ pub fn int_query(c: &mut Criterion) {
                 channel_service,
                 Some(payload_index),
                 generate_points(NUM_POINTS),
+                false,
             )
             .await
         });
@@ -52,6 +53,7 @@ pub fn int_query(c: &mut Criterion) {
                 channel_service,
                 Some(payload_index),
                 generate_points(NUM_POINTS),
+                false,
             )
             .await
         });

--- a/benches/collection/query.rs
+++ b/benches/collection/query.rs
@@ -5,23 +5,21 @@ use crate::common::{
     create_tempdir, generate_int_queries, generate_points, CONCURRENCY, NUM_POINTS, NUM_QUERIES,
 };
 use criterion::Criterion;
-use futures::{
-    executor::block_on,
-    stream::{self, StreamExt},
-};
+use futures::stream::{self, StreamExt};
 use smoldb::storage::index::payload_index::IndexConfig;
 
 pub fn int_query(c: &mut Criterion) {
     let mut group = benchmark_group(c, "query/int");
 
+    let rt = create_runtime();
+
     // Perf when bench was first implemented: 31.807 µs
     // Query a single point while there are NUM_POINTS points in the collection
-    group.bench_function("single", |b| {
-        let rt = create_runtime();
+    {
         let query = generate_int_queries(1).first().unwrap().clone();
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
-        let collection = block_on(async {
+        let collection = rt.block_on(async {
             let payload_index = BTreeMap::from_iter([("price".to_string(), IndexConfig::Int)]);
             create_collection_with_points(
                 &tempdir,
@@ -31,10 +29,12 @@ pub fn int_query(c: &mut Criterion) {
             )
             .await
         });
-        b.to_async(&rt).iter(|| async {
-            collection.query_points(query.clone(), true).await.unwrap();
+        group.bench_function("single", |b| {
+            b.to_async(&rt).iter(|| async {
+                collection.query_points(query.clone(), true).await.unwrap();
+            });
         });
-    });
+    }
 
     // ToDo: Query a single batch of RW_BATCH_SIZE points while there are NUM_POINTS points in the collection
     // It needs support from the API to pass a batch of queries
@@ -42,11 +42,10 @@ pub fn int_query(c: &mut Criterion) {
     // Perf when bench was first implemented: 668.48 µs
     // For querying, batch size is always 1 (for now)
     // So we can just run num_queries queries in CONCURRENCY parallel with batch size=1
-    group.bench_function("concurrent", |b: &mut criterion::Bencher<'_>| {
-        let rt = create_runtime();
+    {
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
-        let collection = block_on(async {
+        let collection = rt.block_on(async {
             let payload_index = BTreeMap::from_iter([("price".to_string(), IndexConfig::Int)]);
             create_collection_with_points(
                 &tempdir,
@@ -62,16 +61,18 @@ pub fn int_query(c: &mut Criterion) {
         // Create queries for different chunks
         let queries = generate_int_queries(NUM_QUERIES);
 
-        b.to_async(&rt).iter(|| async {
-            let queries = queries.clone();
-            stream::iter(queries)
-                .map(|query| {
-                    let collection_clone = collection_arc.clone();
-                    async move { collection_clone.query_points(query, true).await.unwrap() }
-                })
-                .buffer_unordered(CONCURRENCY)
-                .collect::<Vec<_>>()
-                .await;
+        group.bench_function("concurrent", |b: &mut criterion::Bencher<'_>| {
+            b.to_async(&rt).iter(|| async {
+                let queries = queries.clone();
+                stream::iter(queries)
+                    .map(|query| {
+                        let collection_clone = collection_arc.clone();
+                        async move { collection_clone.query_points(query, true).await.unwrap() }
+                    })
+                    .buffer_unordered(CONCURRENCY)
+                    .collect::<Vec<_>>()
+                    .await;
+            });
         });
-    });
+    }
 }

--- a/benches/collection/read.rs
+++ b/benches/collection/read.rs
@@ -25,6 +25,7 @@ pub fn read(c: &mut Criterion) {
                 channel_service,
                 None,
                 generate_points(NUM_POINTS), // insert many points but query only for the last one
+                false,
             )
             .await
         });
@@ -49,6 +50,7 @@ pub fn read(c: &mut Criterion) {
                 channel_service,
                 None,
                 generate_points(NUM_POINTS),
+                false,
             )
             .await
         });
@@ -77,7 +79,7 @@ pub fn read(c: &mut Criterion) {
         let points = generate_points(NUM_POINTS);
         let all_point_ids = points.iter().map(|p| p.id.clone()).collect::<Vec<_>>();
         let collection = rt.block_on(async {
-            create_collection_with_points(&tempdir, channel_service, None, points).await
+            create_collection_with_points(&tempdir, channel_service, None, points, false).await
         });
         let collection_arc = Arc::new(collection);
 

--- a/benches/collection/read.rs
+++ b/benches/collection/read.rs
@@ -1,10 +1,7 @@
 use std::sync::Arc;
 
 use criterion::{Criterion, Throughput};
-use futures::{
-    executor::block_on,
-    stream::{self, StreamExt},
-};
+use futures::stream::{self, StreamExt};
 use smoldb::storage::segment::PointId;
 
 use crate::common::{
@@ -22,7 +19,7 @@ pub fn read(c: &mut Criterion) {
         let rt = create_runtime();
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
-        let collection = block_on(async {
+        let collection = rt.block_on(async {
             create_collection_with_points(
                 &tempdir,
                 channel_service,
@@ -46,7 +43,7 @@ pub fn read(c: &mut Criterion) {
 
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
-        let collection = block_on(async {
+        let collection = rt.block_on(async {
             create_collection_with_points(
                 &tempdir,
                 channel_service,
@@ -78,7 +75,7 @@ pub fn read(c: &mut Criterion) {
         let channel_service = create_channel_service();
         let points = generate_points(NUM_POINTS);
         let all_point_ids = points.iter().map(|p| p.id.clone()).collect::<Vec<_>>();
-        let collection = block_on(async {
+        let collection = rt.block_on(async {
             create_collection_with_points(&tempdir, channel_service, None, points).await
         });
         let collection_arc = Arc::new(collection);

--- a/benches/collection/read.rs
+++ b/benches/collection/read.rs
@@ -11,12 +11,12 @@ use crate::common::{
 
 pub fn read(c: &mut Criterion) {
     let mut group = benchmark_group(c, "read");
+    let rt = create_runtime();
 
     // Perf in the beginning: ???
     // Perf with hashring and tokio: 729.73 ns
     // Read a single point when there are NUM_POINTS points in the collection
-    group.bench_function("single", |b| {
-        let rt = create_runtime();
+    {
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
         let collection = rt.block_on(async {
@@ -28,19 +28,19 @@ pub fn read(c: &mut Criterion) {
             )
             .await
         });
-        b.to_async(&rt).iter(|| async {
-            collection
-                .read_points(Some(vec![PointId::Id(NUM_POINTS - 1)]), None, true)
-                .await
-                .unwrap();
-        });
-    });
+
+        group.bench_function("single", |b| {
+            b.to_async(&rt).iter(|| async {
+                collection
+                    .read_points(Some(vec![PointId::Id(NUM_POINTS - 1)]), None, true)
+                    .await
+                    .unwrap();
+            });
+        })
+    };
 
     // Read 1 batch of BATCH_SIZE points while there are NUM_POINTS points in the collection
-    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
-    group.bench_function("batch", |b| {
-        let rt = create_runtime();
-
+    {
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
         let collection = rt.block_on(async {
@@ -56,44 +56,49 @@ pub fn read(c: &mut Criterion) {
             .map(|i| PointId::Id(i as u64))
             .collect::<Vec<_>>();
 
-        b.to_async(&rt).iter(|| async {
-            collection
-                .read_points(Some(read_batch.clone()), None, true)
-                .await
-                .unwrap();
-        });
-    });
+        group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+        group.bench_function("batch", |b| {
+            b.to_async(&rt).iter(|| async {
+                collection
+                    .read_points(Some(read_batch.clone()), None, true)
+                    .await
+                    .unwrap();
+            });
+        })
+    };
 
     // Perf in the beginning: ???
     // Perf with hashring and tokio: 124.54ms (100_000 points, 4 threads, 2 shards; only 170x slower than single read)
     // Read NUM_POINTS points in NUM_THREADS parallel batches of BATCH_SIZE points
-    group.throughput(Throughput::Elements(NUM_POINTS));
-    group.bench_function("concurrent", |b| {
-        let rt = create_runtime();
-
+    {
         let tempdir = create_tempdir();
-        let channel_service = create_channel_service();
+        let channel_service: Arc<smoldb::channel_service::ChannelService> =
+            create_channel_service();
         let points = generate_points(NUM_POINTS);
         let all_point_ids = points.iter().map(|p| p.id.clone()).collect::<Vec<_>>();
         let collection = rt.block_on(async {
             create_collection_with_points(&tempdir, channel_service, None, points).await
         });
         let collection_arc = Arc::new(collection);
-        b.to_async(&rt).iter(|| async {
-            stream::iter(all_point_ids.chunks(BATCH_SIZE))
-                .map(|chunk| {
-                    let collection_clone = collection_arc.clone();
-                    let chunk = chunk.to_vec();
-                    async move {
-                        collection_clone
-                            .read_points(Some(chunk), None, true)
-                            .await
-                            .unwrap()
-                    }
-                })
-                .buffer_unordered(CONCURRENCY)
-                .collect::<Vec<_>>()
-                .await;
+
+        group.throughput(Throughput::Elements(NUM_POINTS));
+        group.bench_function("concurrent", |b| {
+            b.to_async(&rt).iter(|| async {
+                stream::iter(all_point_ids.chunks(BATCH_SIZE))
+                    .map(|chunk| {
+                        let collection_clone = collection_arc.clone();
+                        let chunk = chunk.to_vec();
+                        async move {
+                            collection_clone
+                                .read_points(Some(chunk), None, true)
+                                .await
+                                .unwrap()
+                        }
+                    })
+                    .buffer_unordered(CONCURRENCY)
+                    .collect::<Vec<_>>()
+                    .await;
+            });
         });
-    });
+    }
 }

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
     create_tempdir, generate_points, generate_text_queries, CONCURRENCY, NUM_POINTS, NUM_QUERIES,
+    TEXT_FIELD,
 };
 use criterion::{Criterion, Throughput};
 use futures::stream::{self, StreamExt};
@@ -19,7 +20,7 @@ pub fn text_query(c: &mut Criterion) {
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
         let collection = rt.block_on(async {
-            let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
+            let payload_index = BTreeMap::from_iter([(TEXT_FIELD.to_string(), IndexConfig::Text)]);
             create_collection_with_points(
                 &tempdir,
                 channel_service,
@@ -44,7 +45,7 @@ pub fn text_query(c: &mut Criterion) {
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
         let collection = rt.block_on(async {
-            let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
+            let payload_index = BTreeMap::from_iter([(TEXT_FIELD.to_string(), IndexConfig::Text)]);
             create_collection_with_points(
                 &tempdir,
                 channel_service,

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -26,6 +26,7 @@ pub fn text_query(c: &mut Criterion) {
                 channel_service,
                 Some(payload_index),
                 generate_points(NUM_POINTS),
+                false,
             )
             .await
         });
@@ -51,6 +52,7 @@ pub fn text_query(c: &mut Criterion) {
                 channel_service,
                 Some(payload_index),
                 generate_points(NUM_POINTS),
+                false,
             )
             .await
         });

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -5,23 +5,20 @@ use crate::common::{
     create_tempdir, generate_points, generate_text_queries, CONCURRENCY, NUM_POINTS, NUM_QUERIES,
 };
 use criterion::{Criterion, Throughput};
-use futures::{
-    executor::block_on,
-    stream::{self, StreamExt},
-};
+use futures::stream::{self, StreamExt};
 use smoldb::storage::index::payload_index::IndexConfig;
 
 // Perf when bench was first implemented: single=1.5804 µs, concurrent=5.7696 µs
 pub fn text_query(c: &mut Criterion) {
     let mut group = benchmark_group(c, "query/text");
+    let rt = create_runtime();
 
     // Single text query benchmark
-    group.bench_function("single", |b| {
-        let rt = create_runtime();
+    {
         let query = generate_text_queries(1).first().unwrap().clone();
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
-        let collection = block_on(async {
+        let collection = rt.block_on(async {
             let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
             create_collection_with_points(
                 &tempdir,
@@ -31,24 +28,22 @@ pub fn text_query(c: &mut Criterion) {
             )
             .await
         });
-        b.to_async(&rt).iter(|| async {
-            collection.query_points(query.clone(), true).await.unwrap();
+
+        group.bench_function("single", |b| {
+            b.to_async(&rt).iter(|| async {
+                collection.query_points(query.clone(), true).await.unwrap();
+            });
         });
-    });
+    }
 
     // todo: Query a single batch of RW_BATCH_SIZE points while there are NUM_POINTS points in the collection
     // It needs support from the API to pass a batch of queries
 
-    group.throughput(Throughput::Elements(NUM_QUERIES as u64));
-
-    // For querying, batch size is always 1 (for now)
-    // So we can just run NUM_QUERIES queries in CONCURRENCY parallel with batch size=1
-    group.bench_function("concurrent", |b| {
-        let rt = create_runtime();
+    {
         let queries = generate_text_queries(NUM_QUERIES);
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
-        let collection = block_on(async {
+        let collection = rt.block_on(async {
             let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
             create_collection_with_points(
                 &tempdir,
@@ -59,15 +54,21 @@ pub fn text_query(c: &mut Criterion) {
             .await
         });
         let collection_arc = Arc::new(collection);
-        b.to_async(&rt).iter(|| async {
-            stream::iter(queries.clone())
-                .map(|query| {
-                    let collection_clone = collection_arc.clone();
-                    async move { collection_clone.query_points(query, true).await.unwrap() }
-                })
-                .buffer_unordered(CONCURRENCY)
-                .collect::<Vec<_>>()
-                .await;
+
+        // For querying, batch size is always 1 (for now)
+        // So we can just run NUM_QUERIES queries in CONCURRENCY parallel with batch size=1
+        group.throughput(Throughput::Elements(NUM_QUERIES as u64));
+        group.bench_function("concurrent", |b| {
+            b.to_async(&rt).iter(|| async {
+                stream::iter(queries.clone())
+                    .map(|query| {
+                        let collection_clone = collection_arc.clone();
+                        async move { collection_clone.query_points(query, true).await.unwrap() }
+                    })
+                    .buffer_unordered(CONCURRENCY)
+                    .collect::<Vec<_>>()
+                    .await;
+            });
         });
-    });
+    }
 }

--- a/benches/collection/write.rs
+++ b/benches/collection/write.rs
@@ -1,10 +1,7 @@
 use std::sync::Arc;
 
 use criterion::{Criterion, Throughput};
-use futures::{
-    executor::block_on,
-    stream::{self, StreamExt},
-};
+use futures::stream::{self, StreamExt};
 
 use crate::common::{
     benchmark_group, create_channel_service, create_collection, create_runtime, create_tempdir,
@@ -21,7 +18,7 @@ pub fn write(c: &mut Criterion) {
         let rt = create_runtime();
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
-        let collection = block_on(async {
+        let collection = rt.block_on(async {
             create_collection("test_collection", &tempdir, channel_service, None).await
         });
         let single_point_batch = generate_points(1);
@@ -40,7 +37,7 @@ pub fn write(c: &mut Criterion) {
         let rt = create_runtime();
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
-        let collection = block_on(async {
+        let collection = rt.block_on(async {
             create_collection("test_collection", &tempdir, channel_service, None).await
         });
         let write_batch = generate_points(BATCH_SIZE as u64);
@@ -61,7 +58,7 @@ pub fn write(c: &mut Criterion) {
         let rt = create_runtime();
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
-        let collection = block_on(async {
+        let collection = rt.block_on(async {
             create_collection("test_collection", &tempdir, channel_service, None).await
         });
         let collection_arc = Arc::new(collection);

--- a/benches/collection/write.rs
+++ b/benches/collection/write.rs
@@ -10,52 +10,51 @@ use crate::common::{
 
 pub fn write(c: &mut Criterion) {
     let mut group = benchmark_group(c, "write");
+    let rt = create_runtime();
 
     // Takes 619.19 ns on my machine
     // After hashring and tokio: 874.32 ns
     // Write a single point in a collection with 0-1 points
-    group.bench_function("single", |b| {
-        let rt = create_runtime();
+    {
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
         let collection = rt.block_on(async {
             create_collection("test_collection", &tempdir, channel_service, None).await
         });
         let single_point_batch = generate_points(1);
-        b.to_async(&rt).iter(|| async {
-            collection
-                .upsert_points(single_point_batch.to_vec(), true)
-                .await
-                .unwrap();
-        })
-    });
 
-    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+        group.bench_function("single", |b| {
+            b.to_async(&rt).iter(|| async {
+                collection
+                    .upsert_points(single_point_batch.to_vec(), true)
+                    .await
+                    .unwrap();
+            })
+        });
+    }
 
-    // Write a single sequential batch of BATCH_SIZE points in an **empty** collection
-    group.bench_function("batch", |b| {
-        let rt = create_runtime();
+    {
         let tempdir = create_tempdir();
-        let channel_service = create_channel_service();
+        let channel_service: Arc<smoldb::channel_service::ChannelService> =
+            create_channel_service();
         let collection = rt.block_on(async {
             create_collection("test_collection", &tempdir, channel_service, None).await
         });
         let write_batch = generate_points(BATCH_SIZE as u64);
-        b.to_async(&rt).iter(|| async {
-            collection
-                .upsert_points(write_batch.to_vec(), true)
-                .await
-                .unwrap();
-        });
-    });
 
-    group.throughput(Throughput::Elements(NUM_POINTS));
+        // Write a single sequential batch of BATCH_SIZE points in an **empty** collection
+        group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+        group.bench_function("batch", |b| {
+            b.to_async(&rt).iter(|| async {
+                collection
+                    .upsert_points(write_batch.to_vec(), true)
+                    .await
+                    .unwrap();
+            });
+        })
+    };
 
-    // Write sequential NUM_POINTS points in CONCURRENCY parallel batches of BATCH_SIZE points in an **empty** collection
-    // Takes 68.347 ms on my machine
-    // After hashring and tokio: 172.99ms
-    group.bench_function("concurrent", |b| {
-        let rt = create_runtime();
+    {
         let tempdir = create_tempdir();
         let channel_service = create_channel_service();
         let collection = rt.block_on(async {
@@ -63,20 +62,28 @@ pub fn write(c: &mut Criterion) {
         });
         let collection_arc = Arc::new(collection);
         let all_points = generate_points(NUM_POINTS);
-        b.to_async(&rt).iter(|| async {
-            stream::iter(all_points.chunks(BATCH_SIZE))
-                .map(|write_batch| {
-                    let collection_clone = collection_arc.clone();
-                    async move {
-                        collection_clone
-                            .upsert_points(write_batch.to_vec(), true)
-                            .await
-                            .unwrap()
-                    }
-                })
-                .buffer_unordered(CONCURRENCY)
-                .collect::<Vec<_>>()
-                .await;
+
+        group.throughput(Throughput::Elements(NUM_POINTS));
+
+        // Write sequential NUM_POINTS points in CONCURRENCY parallel batches of BATCH_SIZE points in an **empty** collection
+        // Takes 68.347 ms on my machine
+        // After hashring and tokio: 172.99ms
+        group.bench_function("concurrent", |b| {
+            b.to_async(&rt).iter(|| async {
+                stream::iter(all_points.chunks(BATCH_SIZE))
+                    .map(|write_batch| {
+                        let collection_clone = collection_arc.clone();
+                        async move {
+                            collection_clone
+                                .upsert_points(write_batch.to_vec(), true)
+                                .await
+                                .unwrap()
+                        }
+                    })
+                    .buffer_unordered(CONCURRENCY)
+                    .collect::<Vec<_>>()
+                    .await;
+            });
         });
-    });
+    }
 }

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -397,7 +397,7 @@ impl CollectionInfo {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use crate::storage::index::filter::{FilterOperator, QueryFilter};
 
@@ -545,7 +545,15 @@ mod tests {
         assert_eq!(read_points[0], points[0]);
 
         // Wait for indexing to complete:
-        tokio::time::sleep(Duration::from_millis(1100)).await;
+        let start_time = Instant::now();
+        while start_time.elapsed() < Duration::from_secs(60) {
+            // Always sleep a little first because indexing queue might be picked up but not yet processed
+            tokio::time::sleep(Duration::from_millis(110)).await;
+            let pending_indexing_count = collection.get_pending_indexing_count(None).await;
+            if pending_indexing_count == 0 {
+                break;
+            }
+        }
 
         let query = Query {
             filter: QueryFilter::new("age", json!(25), FilterOperator::Gte),

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -18,7 +18,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, RwLockReadGuard};
 use utoipa::ToSchema;
 
 pub const COLLECTION_CONFIG_FILE: &str = "config.json";
@@ -316,6 +316,22 @@ impl Collection {
 
         Ok(all_points.into_values().collect())
     }
+
+    pub async fn get_pending_indexing_count(
+        &self,
+        shard_holder: Option<&RwLockReadGuard<'_, ReplicaHolder>>,
+    ) -> usize {
+        let shard_holder = match shard_holder {
+            Some(shard_holder) => shard_holder,
+            None => &self.replica_holder.read().await,
+        };
+
+        shard_holder
+            .shards
+            .values()
+            .map(|replica_set| replica_set.local.get_pending_indexing_count())
+            .sum()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
@@ -361,11 +377,9 @@ pub struct CollectionInfo {
 impl CollectionInfo {
     pub async fn from(collection: &Collection) -> Self {
         let shard_holder = collection.replica_holder.read().await;
-        let pending_indexing_count: usize = shard_holder
-            .shards
-            .values()
-            .map(|replica_set| replica_set.local.get_pending_indexing_count())
-            .sum();
+        let pending_indexing_count = collection
+            .get_pending_indexing_count(Some(&shard_holder))
+            .await;
 
         CollectionInfo {
             id: collection.id.clone(),

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -375,6 +375,8 @@ impl CollectionInfo {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use crate::storage::index::filter::{FilterOperator, QueryFilter};
 
     use super::*;
@@ -519,6 +521,9 @@ mod tests {
 
         assert_eq!(read_points.len(), 1);
         assert_eq!(read_points[0], points[0]);
+
+        // Wait for indexing to complete:
+        tokio::time::sleep(Duration::from_millis(1100)).await;
 
         let query = Query {
             filter: QueryFilter::new("age", json!(25), FilterOperator::Gte),

--- a/src/storage/collection.rs
+++ b/src/storage/collection.rs
@@ -355,11 +355,18 @@ pub struct CollectionInfo {
     pub config: CollectionConfig,
     pub shard_count: usize,
     pub segment_count: usize,
+    pub pending_indexing_count: usize,
 }
 
 impl CollectionInfo {
     pub async fn from(collection: &Collection) -> Self {
         let shard_holder = collection.replica_holder.read().await;
+        let pending_indexing_count: usize = shard_holder
+            .shards
+            .values()
+            .map(|replica_set| replica_set.local.get_pending_indexing_count())
+            .sum();
+
         CollectionInfo {
             id: collection.id.clone(),
             config: collection.config.clone(),
@@ -369,6 +376,7 @@ impl CollectionInfo {
                 .values()
                 .map(|shard| shard.local.segments.len())
                 .sum(),
+            pending_indexing_count,
         }
     }
 }

--- a/src/storage/replicas/local_shard.rs
+++ b/src/storage/replicas/local_shard.rs
@@ -11,6 +11,8 @@ use crate::{
 use std::{
     collections::{BTreeMap, HashMap},
     path::PathBuf,
+    sync::Arc,
+    thread::JoinHandle,
 };
 use tonic::async_trait;
 
@@ -19,8 +21,9 @@ const SEGMENTS_DIR: &str = "segments";
 pub struct LocalShard {
     pub id: ShardId,
     pub path: PathBuf,
-    pub segments: HashMap<SegmentId, Segment>,
+    pub segments: HashMap<SegmentId, Arc<Segment>>,
     pub shard_state: ShardState,
+    _indexing_threads: HashMap<SegmentId, JoinHandle<()>>,
     // ToDo: Wal
 }
 
@@ -68,6 +71,22 @@ impl ShardOperationTrait for LocalShard {
 }
 
 impl LocalShard {
+    /// Spawns a dedicated thread to run the indexing loop for a segment
+    fn spawn_indexing_thread(segment_id: SegmentId, segment: Arc<Segment>) -> JoinHandle<()> {
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to create tokio runtime for indexing thread");
+
+            rt.block_on(async {
+                if let Err(e) = segment.run_indexing_loop().await {
+                    log::error!("Indexing loop error for segment {}: {}", segment_id, e);
+                }
+            });
+        })
+    }
+
     pub fn init(
         path: PathBuf,
         id: ShardId,
@@ -81,11 +100,22 @@ impl LocalShard {
         let segment0 = Segment::create(&segments_dir, payload_schema)
             .expect("Failed to create initial segment");
 
+        let segment0_arc = Arc::new(segment0);
+        let segment0_clone = segment0_arc.clone();
+        let indexing_thread = Self::spawn_indexing_thread(0, segment0_clone);
+
+        let mut segments = HashMap::new();
+        segments.insert(0, segment0_arc);
+
+        let mut indexing_threads = HashMap::new();
+        indexing_threads.insert(0, indexing_thread);
+
         LocalShard {
             id,
             path: path.to_owned(),
-            segments: HashMap::from_iter([(0, segment0)]),
+            segments,
             shard_state: ShardState::Active,
+            _indexing_threads: indexing_threads,
         }
     }
 
@@ -115,9 +145,16 @@ impl LocalShard {
             ))?;
 
         let mut segments = HashMap::new();
-        for (id, segment_path) in segment_paths {
+        let mut indexing_threads = HashMap::new();
+
+        for (segment_id, segment_path) in segment_paths {
             let segment = Segment::load(&segment_path)?;
-            segments.insert(id, segment);
+            let segment_arc = Arc::new(segment);
+            let segment_clone = segment_arc.clone();
+            let indexing_thread = Self::spawn_indexing_thread(segment_id, segment_clone);
+
+            indexing_threads.insert(segment_id, indexing_thread);
+            segments.insert(segment_id, segment_arc);
         }
 
         Ok(Self {
@@ -125,6 +162,7 @@ impl LocalShard {
             path: path.to_owned(),
             segments,
             shard_state: ShardState::Active, // ToDo: Load from disk?
+            _indexing_threads: indexing_threads,
         })
     }
 

--- a/src/storage/replicas/local_shard.rs
+++ b/src/storage/replicas/local_shard.rs
@@ -173,4 +173,12 @@ impl LocalShard {
             0
         }
     }
+
+    /// Get the total count of pending points in the indexing queue across all segments
+    pub fn get_pending_indexing_count(&self) -> usize {
+        self.segments
+            .values()
+            .filter_map(|segment| segment.indexing_queue_length().ok())
+            .sum()
+    }
 }

--- a/src/storage/replicas/local_shard.rs
+++ b/src/storage/replicas/local_shard.rs
@@ -81,7 +81,9 @@ impl LocalShard {
 
             rt.block_on(async {
                 if let Err(e) = segment.run_indexing_loop().await {
-                    log::error!("Indexing loop error for segment {}: {}", segment_id, e);
+                    log::error!("Indexing loop error for segment {}: {}", segment_id, e); // for general logs
+                    eprintln!("Indexing loop error for segment {}: {}", segment_id, e);
+                    // for benches with --nocapture
                 }
             });
         })

--- a/src/storage/segment/index/integer.rs
+++ b/src/storage/segment/index/integer.rs
@@ -123,6 +123,76 @@ impl IntegerIndex {
         })?;
         self.upsert(point_id, num_value)
     }
+
+    pub fn add_points(&self, point_ids: &[u64], values: &[Value]) -> StorageResult<()> {
+        if point_ids.len() != values.len() {
+            return Err(StorageError::BadInput(
+                "Point IDs and values length mismatch".to_string(),
+            ));
+        }
+
+        let values = values
+            .iter()
+            .map(|v| {
+                v.as_i64().ok_or_else(|| {
+                    StorageError::BadInput(format!("Value being inserted is not an integer: {v}"))
+                })
+            })
+            .collect::<Result<Vec<i64>, StorageError>>()?;
+
+        self.upsert_batch(point_ids, &values)?;
+        Ok(())
+    }
+
+    pub fn upsert_batch(&self, point_ids: &[u64], values: &[i64]) -> StorageResult<()> {
+        let mut temp_index: BTreeMap<i64, Vec<u64>> = BTreeMap::new();
+
+        // Group point IDs by their integer values
+        for (&point_id, &value) in point_ids.iter().zip(values.iter()) {
+            temp_index.entry(value).or_default().push(point_id);
+        }
+
+        // Now update the sled tree and in-memory index
+        for (value, mut new_point_ids) in temp_index {
+            let tree_key = encoded_integer_value(value);
+
+            // Fetch existing point IDs for this value
+            let mut point_ids = if let Some(in_memory) = &self.in_memory {
+                in_memory.get_point_ids(value)?
+            } else {
+                self.tree
+                    .get(&tree_key)?
+                    .map(|d| decoded_point_ids(&d))
+                    .transpose()?
+                    .unwrap_or_default()
+            };
+
+            // Merge new point IDs while maintaining sorted order
+            for point_id in new_point_ids.drain(..) {
+                match point_ids.binary_search(&point_id) {
+                    Ok(_) => {
+                        // It already exists, we don't need to do anything
+                    }
+                    Err(pos) => {
+                        point_ids.insert(pos, point_id);
+                    }
+                }
+            }
+
+            // Store back
+            let encoded_ids = encoded_point_ids(&point_ids)?;
+
+            self.tree.insert(&tree_key, encoded_ids).map_err(|e| {
+                StorageError::ServiceError(format!("Failed to insert into index tree: {e}"))
+            })?;
+
+            if let Some(in_memory) = &self.in_memory {
+                in_memory.insert(value, point_ids)?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 struct InMemoryIntegerIndex {

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -9,7 +9,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sled::Db;
-use std::{collections::BTreeMap, sync::Mutex};
+use std::collections::BTreeMap;
 use utoipa::ToSchema;
 
 /// Converts the number into a big-endian value which is suitable for querying/storing in sled
@@ -127,7 +127,6 @@ impl FieldIndexTrait<&Value> for FieldIndex {
 
 pub struct PayloadIndex {
     pub indices: BTreeMap<String, FieldIndex>,
-    pub indexing_queue: Mutex<Vec<PointId>>,
 }
 
 impl PayloadIndex {
@@ -154,10 +153,7 @@ impl PayloadIndex {
             indices.insert(name, field_index);
         }
 
-        Ok(Self {
-            indices,
-            indexing_queue: Mutex::new(Vec::new()),
-        })
+        Ok(Self { indices })
     }
 
     pub fn get_index_names(&self) -> Vec<&str> {
@@ -214,45 +210,6 @@ impl PayloadIndex {
             }
         }
         Ok(())
-    }
-
-    /// Send some points to be indexed to the indexing queue
-    pub fn queue(&self, point_id: &PointId) -> StorageResult<()> {
-        let mut guard = self.indexing_queue.lock().map_err(|e| {
-            StorageError::ServiceError(format!("Failed to lock indexing queue: {}", e))
-        })?;
-        guard.push(point_id.clone());
-        Ok(())
-    }
-
-    pub fn run_indexing_loop<F>(&self, read_points: F) -> StorageResult<()>
-    where
-        F: Fn(&[PointId]) -> StorageResult<Vec<Point>>,
-    {
-        let mut point_ids = Vec::new();
-
-        loop {
-            // Wait till we get 100 points to index in a batch:
-            const INDEXING_THRESHOLD: usize = 100;
-            while point_ids.len() < INDEXING_THRESHOLD {
-                let mut guard = self.indexing_queue.lock().map_err(|e| {
-                    StorageError::ServiceError(format!("Failed to lock indexing queue: {}", e))
-                })?;
-                // Instead, wait for a bit and check again:
-                let Some(point_id) = guard.pop() else {
-                    std::thread::sleep(std::time::Duration::from_millis(10));
-                    continue;
-                };
-
-                drop(guard);
-                point_ids.push(point_id);
-            }
-
-            let points = read_points(&point_ids)?;
-
-            self.insert_batch(&points)?;
-            point_ids.clear();
-        }
     }
 
     pub fn insert_batch(&self, points: &[Point]) -> StorageResult<()> {

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -213,24 +213,24 @@ impl PayloadIndex {
     }
 
     pub fn insert_batch(&self, points: &[Point]) -> StorageResult<()> {
-        // Ensure point Ids are u64 type:
-        let point_ids = points.iter().map(|point| {
-            let PointId::Id(id) = point.id else {
-                return Err(StorageError::BadInput("Invalid PointId type: Only u64 point ID is supported for payload indexing (for now)".to_string()));
-            };
-            Ok(id)
-        }).collect::<Result<Vec<u64>, _>>()?;
-
         for (index_key, index_tree) in &self.indices {
-            let index_values = points
-                .iter()
-                .filter_map(|point| {
-                    // Skipping points that don't have a value for the index key
-                    point.payload.get(index_key).cloned()
-                })
-                .collect::<Vec<Value>>();
+            // Collect both point_ids and values together, only for points that have the index key
+            let mut point_ids = Vec::new();
+            let mut index_values = Vec::new();
 
-            index_tree.add_points(&point_ids, &index_values)?;
+            for point in points {
+                if let Some(value) = point.payload.get(index_key) {
+                    let PointId::Id(id) = point.id else {
+                        return Err(StorageError::BadInput("Invalid PointId type: Only u64 point ID is supported for payload indexing (for now)".to_string()));
+                    };
+                    point_ids.push(id);
+                    index_values.push(value.clone());
+                }
+            }
+
+            if !point_ids.is_empty() {
+                index_tree.add_points(&point_ids, &index_values)?;
+            }
         }
 
         Ok(())

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -9,7 +9,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sled::Db;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Mutex};
 use utoipa::ToSchema;
 
 /// Converts the number into a big-endian value which is suitable for querying/storing in sled
@@ -73,6 +73,16 @@ impl FieldIndexTrait<&Value> for FieldIndex {
         }
     }
 
+    fn add_points(&self, point_ids: &[u64], values: &[Value]) -> StorageResult<()> {
+        match self {
+            FieldIndex::Int(index) => index.add_points(point_ids, values),
+            FieldIndex::Text(index) => index.add_points(point_ids, values),
+            FieldIndex::Null => Err(StorageError::BadInput(
+                "Null index is not supported yet".to_string(),
+            )),
+        }
+    }
+
     fn open(_db: &Db, _name: &str, _use_in_memory: bool) -> StorageResult<Self> {
         Err(StorageError::BadInput(
             "Use specific index constructors like new_numeric or new_text".to_string(),
@@ -117,6 +127,7 @@ impl FieldIndexTrait<&Value> for FieldIndex {
 
 pub struct PayloadIndex {
     pub indices: BTreeMap<String, FieldIndex>,
+    pub indexing_queue: Mutex<Vec<PointId>>,
 }
 
 impl PayloadIndex {
@@ -143,7 +154,10 @@ impl PayloadIndex {
             indices.insert(name, field_index);
         }
 
-        Ok(Self { indices })
+        Ok(Self {
+            indices,
+            indexing_queue: Mutex::new(Vec::new()),
+        })
     }
 
     pub fn get_index_names(&self) -> Vec<&str> {
@@ -202,6 +216,69 @@ impl PayloadIndex {
         Ok(())
     }
 
+    /// Send some points to be indexed to the indexing queue
+    pub fn queue(&self, point_id: &PointId) -> StorageResult<()> {
+        let mut guard = self.indexing_queue.lock().map_err(|e| {
+            StorageError::ServiceError(format!("Failed to lock indexing queue: {}", e))
+        })?;
+        guard.push(point_id.clone());
+        Ok(())
+    }
+
+    pub fn run_indexing_loop<F>(&self, read_points: F) -> StorageResult<()>
+    where
+        F: Fn(&[PointId]) -> StorageResult<Vec<Point>>,
+    {
+        let mut point_ids = Vec::new();
+
+        loop {
+            // Wait till we get 100 points to index in a batch:
+            const INDEXING_THRESHOLD: usize = 100;
+            while point_ids.len() < INDEXING_THRESHOLD {
+                let mut guard = self.indexing_queue.lock().map_err(|e| {
+                    StorageError::ServiceError(format!("Failed to lock indexing queue: {}", e))
+                })?;
+                // Instead, wait for a bit and check again:
+                let Some(point_id) = guard.pop() else {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    continue;
+                };
+
+                drop(guard);
+                point_ids.push(point_id);
+            }
+
+            let points = read_points(&point_ids)?;
+
+            self.insert_batch(&points)?;
+            point_ids.clear();
+        }
+    }
+
+    pub fn insert_batch(&self, points: &[Point]) -> StorageResult<()> {
+        // Ensure point Ids are u64 type:
+        let point_ids = points.iter().map(|point| {
+            let PointId::Id(id) = point.id else {
+                return Err(StorageError::BadInput("Invalid PointId type: Only u64 point ID is supported for payload indexing (for now)".to_string()));
+            };
+            Ok(id)
+        }).collect::<Result<Vec<u64>, _>>()?;
+
+        for (index_key, index_tree) in &self.indices {
+            let index_values = points
+                .iter()
+                .filter_map(|point| {
+                    // Skipping points that don't have a value for the index key
+                    point.payload.get(index_key).cloned()
+                })
+                .collect::<Vec<Value>>();
+
+            index_tree.add_points(&point_ids, &index_values)?;
+        }
+
+        Ok(())
+    }
+
     // Todo: Support deleting points from the index in case of update or deletes
 
     pub fn query(&self, query: Query) -> StorageResult<Vec<PointId>> {
@@ -218,7 +295,7 @@ impl PayloadIndex {
     }
 }
 
-pub trait FieldIndexTrait<DataType> {
+pub trait FieldIndexTrait<QueryValueType> {
     /// Create or load an index from the DB
     ///
     /// Note for `use_in_memory`:
@@ -229,10 +306,12 @@ pub trait FieldIndexTrait<DataType> {
         Self: Sized;
     /// Add a point to the index
     fn add_point(&self, point_id: u64, value: &Value) -> StorageResult<()>;
+    /// Add points to the index (for bulk indexing)
+    fn add_points(&self, point_ids: &[u64], values: &[Value]) -> StorageResult<()>;
     /// Query the index
     fn query(
         &self,
-        value: DataType,
+        value: QueryValueType,
         operation: &FilterOperator,
         limit: Option<usize>,
     ) -> StorageResult<Vec<PointId>>;

--- a/src/storage/segment/index/text.rs
+++ b/src/storage/segment/index/text.rs
@@ -120,6 +120,65 @@ impl FieldIndexTrait<&str> for TextIndex {
 
         Ok(results)
     }
+
+    fn add_points(&self, point_ids: &[u64], values: &[Value]) -> StorageResult<()> {
+        if point_ids.len() != values.len() {
+            return Err(StorageError::BadInput(
+                "Point IDs and values length mismatch".to_string(),
+            ));
+        }
+
+        let texts = values
+            .iter()
+            .map(|v| {
+                v.as_str().ok_or_else(|| {
+                    StorageError::BadInput(format!("Value being inserted is not a string: {v}"))
+                })
+            })
+            .collect::<Result<Vec<&str>, StorageError>>()?;
+
+        // Now build a temporary index in memory to avoid multiple passes over the data:
+        let mut temp_index: HashMap<String, Vec<PostingListItem>> = HashMap::new();
+        for (point_id, text) in point_ids.iter().zip(texts.iter()) {
+            let terms = tokenize_and_count_frequencies(text);
+            for (term, term_freq) in terms {
+                temp_index
+                    .entry(term)
+                    .or_default()
+                    .push(PostingListItem::new(*point_id, term_freq));
+            }
+        }
+
+        // Merge the temporary index into the main index:
+        for (term, mut new_posting_list) in temp_index {
+            let term_key = term.as_bytes();
+            let mut posting_list = if let Some(in_memory_index) = &self.in_memory_index {
+                in_memory_index.get_term_posting_list(&term)?
+            } else {
+                self.db
+                    .get(term_key)?
+                    .map(|data| PostingListItem::decode_list(&data))
+                    .transpose()?
+                    .unwrap_or_default()
+            };
+            posting_list.append(&mut new_posting_list);
+            posting_list.sort_by_key(|item| item.doc_id);
+            let encoded_posting_list = PostingListItem::encode_list(&posting_list)?;
+            self.db
+                .insert(term_key, encoded_posting_list)
+                .map_err(|e| {
+                    StorageError::ServiceError(format!(
+                        "Failed to insert into text index tree: {e}"
+                    ))
+                })?;
+            if let Some(in_memory_index) = &self.in_memory_index {
+                // Also updates the stats in the in-memory index
+                in_memory_index.override_term_posting_list(&term, posting_list)?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 // todo: Remove this layer and use the BM25Index directly

--- a/src/storage/segment/mod.rs
+++ b/src/storage/segment/mod.rs
@@ -207,7 +207,7 @@ impl Segment {
     /// Runs the background indexing loop, batching points efficiently.
     pub async fn run_indexing_loop(&self) -> StorageResult<()> {
         const INDEXING_THRESHOLD: usize = 100;
-        const INDEXING_INTERVAL_MS: u64 = 1000;
+        const INDEXING_INTERVAL_MS: u64 = 100;
         const SLEEP_MS: u64 = 10;
 
         let mut point_ids = Vec::with_capacity(INDEXING_THRESHOLD);

--- a/src/storage/segment/mod.rs
+++ b/src/storage/segment/mod.rs
@@ -194,6 +194,14 @@ impl Segment {
         self.db.len()
     }
 
+    /// Get the current indexing queue length
+    pub fn indexing_queue_length(&self) -> StorageResult<usize> {
+        let queue = self.indexing_queue.lock().map_err(|e| {
+            StorageError::ServiceError(format!("Failed to lock indexing queue: {e}"))
+        })?;
+        Ok(queue.len())
+    }
+
     /// Runs the background indexing loop, batching points efficiently.
     pub async fn run_indexing_loop(&self) -> StorageResult<()> {
         const INDEXING_THRESHOLD: usize = 100;

--- a/src/storage/segment/mod.rs
+++ b/src/storage/segment/mod.rs
@@ -82,13 +82,13 @@ impl Segment {
             self.db.insert(key, value).map_err(|e| {
                 StorageError::ServiceError(format!("Failed to insert point into segment db: {e}"))
             })?;
-
-            // self.payload_index.upsert(point).map_err(|e| {
-            //     StorageError::ServiceError(format!("Failed to update payload index: {e}"))
-            // })?;
-
-            self.queue_for_indexing(&point.id)?;
         }
+
+        let point_ids = points
+            .iter()
+            .map(|point| point.id.clone())
+            .collect::<Vec<_>>();
+        self.queue_for_indexing(point_ids)?;
 
         self.db
             .flush()
@@ -97,11 +97,13 @@ impl Segment {
     }
 
     /// Send some points to be indexed to the indexing queue
-    pub fn queue_for_indexing(&self, point_id: &PointId) -> StorageResult<()> {
+    /// It takes a lock, so it's better to call it for a batch of points at once
+    pub fn queue_for_indexing(&self, point_ids: Vec<PointId>) -> StorageResult<()> {
+        // todo: Should lock in smaller chunks to avoid long locks?
         let mut guard = self.indexing_queue.lock().map_err(|e| {
             StorageError::ServiceError(format!("Failed to lock indexing queue: {}", e))
         })?;
-        guard.push(point_id.clone());
+        guard.extend(point_ids);
         Ok(())
     }
 

--- a/src/storage/segment/mod.rs
+++ b/src/storage/segment/mod.rs
@@ -10,6 +10,7 @@ use futures::StreamExt;
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
+    thread::JoinHandle,
 };
 
 // re-export point imports
@@ -22,6 +23,7 @@ pub struct Segment {
     // ToDo: ID tracker, vector storage?
     // ID tracker is valuable for building immutable segments, so same point can exist in multiple segments while only the latest version is visible
     pub payload_index: PayloadIndex,
+    pub async_indexer: Option<JoinHandle<()>>,
 }
 
 impl Segment {
@@ -49,6 +51,7 @@ impl Segment {
             path,
             db,
             payload_index,
+            async_indexer: None,
         })
     }
 
@@ -66,6 +69,7 @@ impl Segment {
             path: path.to_owned(),
             db,
             payload_index,
+            async_indexer: None,
         })
     }
 
@@ -78,9 +82,11 @@ impl Segment {
                 StorageError::ServiceError(format!("Failed to insert point into segment db: {e}"))
             })?;
 
-            self.payload_index.upsert(point).map_err(|e| {
-                StorageError::ServiceError(format!("Failed to update payload index: {e}"))
-            })?;
+            // self.payload_index.upsert(point).map_err(|e| {
+            //     StorageError::ServiceError(format!("Failed to update payload index: {e}"))
+            // })?;
+
+            self.payload_index.queue(&point.id)?;
         }
 
         self.db

--- a/src/storage/segment/mod.rs
+++ b/src/storage/segment/mod.rs
@@ -10,7 +10,9 @@ use futures::StreamExt;
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
+    sync::Mutex,
     thread::JoinHandle,
+    time::Instant,
 };
 
 // re-export point imports
@@ -23,6 +25,7 @@ pub struct Segment {
     // ToDo: ID tracker, vector storage?
     // ID tracker is valuable for building immutable segments, so same point can exist in multiple segments while only the latest version is visible
     pub payload_index: PayloadIndex,
+    pub indexing_queue: Mutex<Vec<PointId>>,
     pub async_indexer: Option<JoinHandle<()>>,
 }
 
@@ -51,6 +54,7 @@ impl Segment {
             path,
             db,
             payload_index,
+            indexing_queue: Mutex::new(Vec::new()),
             async_indexer: None,
         })
     }
@@ -69,6 +73,7 @@ impl Segment {
             path: path.to_owned(),
             db,
             payload_index,
+            indexing_queue: Mutex::new(Vec::new()),
             async_indexer: None,
         })
     }
@@ -86,12 +91,21 @@ impl Segment {
             //     StorageError::ServiceError(format!("Failed to update payload index: {e}"))
             // })?;
 
-            self.payload_index.queue(&point.id)?;
+            self.queue_for_indexing(&point.id)?;
         }
 
         self.db
             .flush()
             .map_err(|e| StorageError::ServiceError(format!("Failed to flush segment db: {e}")))?;
+        Ok(())
+    }
+
+    /// Send some points to be indexed to the indexing queue
+    pub fn queue_for_indexing(&self, point_id: &PointId) -> StorageResult<()> {
+        let mut guard = self.indexing_queue.lock().map_err(|e| {
+            StorageError::ServiceError(format!("Failed to lock indexing queue: {}", e))
+        })?;
+        guard.push(point_id.clone());
         Ok(())
     }
 
@@ -182,6 +196,46 @@ impl Segment {
 
     pub fn count_points(&self) -> usize {
         self.db.len()
+    }
+
+    /// Runs the background indexing loop, batching points efficiently.
+    pub async fn run_indexing_loop(&self) -> StorageResult<()> {
+        const INDEXING_THRESHOLD: usize = 100;
+        const INDEXING_INTERVAL_MS: u64 = 1000;
+        const SLEEP_MS: u64 = 10;
+
+        let mut point_ids = Vec::with_capacity(INDEXING_THRESHOLD);
+        let mut last_index_time = Instant::now();
+
+        loop {
+            // Fill the batch up to threshold or until interval passes.
+            while point_ids.len() < INDEXING_THRESHOLD
+                && last_index_time.elapsed().as_millis() < INDEXING_INTERVAL_MS as u128
+            {
+                let point_id_opt = {
+                    let mut queue = self.indexing_queue.lock().map_err(|e| {
+                        StorageError::ServiceError(format!(
+                            "Failed to acquire lock on indexing queue: {e}"
+                        ))
+                    })?;
+                    queue.pop()
+                };
+
+                if let Some(point_id) = point_id_opt {
+                    point_ids.push(point_id);
+                } else {
+                    std::thread::sleep(std::time::Duration::from_millis(SLEEP_MS));
+                }
+            }
+
+            if !point_ids.is_empty() {
+                let points = self.get_points(Some(point_ids.clone())).await?;
+                self.payload_index.insert_batch(&points)?;
+                point_ids.clear();
+            }
+
+            last_index_time = Instant::now();
+        }
     }
 
     // todo: Allow updating payload index schema on the fly

--- a/src/storage/segment/mod.rs
+++ b/src/storage/segment/mod.rs
@@ -11,7 +11,6 @@ use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
     sync::Mutex,
-    thread::JoinHandle,
     time::Instant,
 };
 
@@ -26,7 +25,6 @@ pub struct Segment {
     // ID tracker is valuable for building immutable segments, so same point can exist in multiple segments while only the latest version is visible
     pub payload_index: PayloadIndex,
     pub indexing_queue: Mutex<Vec<PointId>>,
-    pub async_indexer: Option<JoinHandle<()>>,
 }
 
 impl Segment {
@@ -55,7 +53,6 @@ impl Segment {
             db,
             payload_index,
             indexing_queue: Mutex::new(Vec::new()),
-            async_indexer: None,
         })
     }
 
@@ -74,7 +71,6 @@ impl Segment {
             db,
             payload_index,
             indexing_queue: Mutex::new(Vec::new()),
-            async_indexer: None,
         })
     }
 
@@ -229,6 +225,11 @@ impl Segment {
             }
 
             if !point_ids.is_empty() {
+                log::info!(
+                    "Indexing {} points. First point ID: {:?}",
+                    point_ids.len(),
+                    point_ids[0]
+                );
                 let points = self.get_points(Some(point_ids.clone())).await?;
                 self.payload_index.insert_batch(&points)?;
                 point_ids.clear();

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+const INDEXING_WAIT_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
 
 pub async fn wait_consensus_ready(url: &Uri) -> Result<(), SmolBenchError> {
     let now = std::time::Instant::now();
@@ -117,7 +118,7 @@ pub async fn create_collection(
     Ok(success_res)
 }
 
-async fn get_collection(
+pub async fn get_collection(
     url: &Uri,
     collection_name: &str,
 ) -> Result<ApiResponse<Value>, SmolBenchError> {
@@ -329,4 +330,55 @@ pub async fn query_points(
         ApiResponse::Success(body) => Ok(body),
         ApiResponse::Error(res) => Err(SmolBenchError::QueryPointsError(res.error)),
     }
+}
+
+/// Wait for indexing to complete by polling the collection info API
+/// and checking that pending_indexing_count reaches 0
+pub async fn wait_for_indexing(url: &Uri, collection_name: &str) -> Result<(), SmolBenchError> {
+    println!("Waiting for indexing to complete for collection '{collection_name}'...");
+    let start_time = std::time::Instant::now();
+    let mut last_count = None;
+
+    while start_time.elapsed() < INDEXING_WAIT_TIMEOUT {
+        let collection_info = get_collection(url, collection_name).await?;
+
+        match collection_info {
+            ApiResponse::Success(info) => {
+                let pending_count = info
+                    .result
+                    .get("pending_indexing_count")
+                    .and_then(|v| v.as_u64())
+                    .ok_or(SmolBenchError::ServiceError(
+                        "Pending indexing count not found".to_string(),
+                    ))?;
+
+                if pending_count == 0 {
+                    if let Some(last) = last_count {
+                        println!("Indexing completed! (was {last} pending)");
+                    } else {
+                        println!("Indexing completed!");
+                    }
+                    return Ok(());
+                }
+
+                // Only print if the count changed
+                if last_count != Some(pending_count) {
+                    println!("Pending indexing: {pending_count} points");
+                    last_count = Some(pending_count);
+                }
+            }
+            ApiResponse::Error(err) => {
+                return Err(SmolBenchError::ServiceError(format!(
+                    "Failed to get collection info: {}",
+                    err.error
+                )));
+            }
+        }
+
+        sleep(Duration::from_millis(500)).await;
+    }
+
+    Err(SmolBenchError::ServiceError(format!(
+        "Timed out waiting for indexing to complete after {INDEXING_WAIT_TIMEOUT:?}"
+    )))
 }

--- a/tools/smolbench/src/args.rs
+++ b/tools/smolbench/src/args.rs
@@ -68,6 +68,10 @@ pub struct Args {
     #[clap(long, default_value = "false")]
     pub skip_upsert: bool,
 
+    /// Skip waiting for indexing to complete after upserting points
+    #[clap(long, default_value = "false")]
+    pub skip_wait_index: bool,
+
     /// Check whether to read points after upsert
     #[clap(long, default_value = "false")]
     pub skip_read: bool,

--- a/tools/smolbench/src/error.rs
+++ b/tools/smolbench/src/error.rs
@@ -16,6 +16,8 @@ pub enum SmolBenchError {
     ReadPointsError(String),
     #[error("Failed to query points: {0}")]
     QueryPointsError(String),
+    #[error("Service error: {0}")]
+    ServiceError(String),
     #[error("Request error: {0}")]
     RequestError(#[from] reqwest::Error),
     #[error("JSON parsing error: {0}")]

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -8,7 +8,10 @@ pub mod types;
 pub mod utils;
 
 use crate::{
-    apis::{create_collection, delete_collection, exists_collection, read_point, upsert_points},
+    apis::{
+        create_collection, delete_collection, exists_collection, read_point, upsert_points,
+        wait_for_indexing,
+    },
     utils::log_latencies,
 };
 use args::parse_args;
@@ -89,6 +92,10 @@ async fn main() -> Result<(), SmolBenchError> {
         .await?;
 
         log_latencies(&batch_responses, args.p9, "server-side batched upsert").await?;
+
+        if !args.skip_wait_index {
+            wait_for_indexing(&args.uri, &args.collection_name).await?;
+        }
     }
 
     if !args.skip_read {


### PR DESCRIPTION
This PR covers the following:
- Batched indexing support for both `text` and `int` index.
- Indexing queue that collects batches and async indexer. So upserts should be faster.
- Expose `indexed_point_count` in `GET /collections/{collection_name}` API
- Use this `indexed_point_count` to wait for indexing in `smolbench` and criterion benches.

We keep a single segment per shard for now. But indexing has been decoupled from upserting without having the concept of mutable vs immutable segments (different from how Qdrant/Elasticsearch work)

Limits of the current approach:
- Points become visible for filters after some time. The effect is more pronounced when the system is under heavy (esp write) load because queue can be long.
- Indexing queue is not persistent so if smoldb crashes before points are indexed, they'll never be queryable via filters (although, points can still be read). Ideally should also add WAL.

Lessons:
- Text indexing in smoldb wasn't progressing and and I was trying hard to look for a deadlock but apparently the indexer thread had crashed silently. Silent failures are very common and dumb. Always have logging enabled or panic. 
- `eprintln` works with `cargo bench -- --nocapture` too.