### PR TITLE
Bulk indexing benches and text index benches

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -37,13 +37,15 @@ jobs:
         run: |
           # Background monitor loop (prints every 3s)
           monitor() {
+            CPU_CORES=$(nproc)
             while true; do
               MEM_USED=$(free -m | awk '/^Mem:/ {printf "%.1f", $3/1024}')
               MEM_TOTAL=$(free -m | awk '/^Mem:/ {printf "%.1f", $2/1024}')
               DISK_USED=$(df $PWD | awk 'NR==2 {printf "%.1f", $3/1024}')
               DISK_TOTAL=$(df $PWD | awk 'NR==2 {printf "%.1f", $2/1024}')
-              echo "memory: ${MEM_USED}GB / ${MEM_TOTAL}GB | disk: ${DISK_USED}GB / ${DISK_TOTAL}GB"
-              sleep 3
+              CPU_PCT=$(mpstat 1 1 | awk 'END {printf "%.0f", 100-$NF}')
+              echo "memory: ${MEM_USED}GB / ${MEM_TOTAL}GB | disk: ${DISK_USED}GB / ${DISK_TOTAL}GB | cpu: ${CPU_PCT}% (${CPU_CORES} cores)"
+              sleep 5
             done
           }
           monitor &

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -35,6 +35,20 @@ jobs:
         id: bench_results
         continue-on-error: true
         run: |
+          # Background monitor loop (prints every 3s)
+          monitor() {
+            while true; do
+              MEM_USED=$(free -m | awk '/^Mem:/ {printf "%.1f", $3/1024}')
+              MEM_TOTAL=$(free -m | awk '/^Mem:/ {printf "%.1f", $2/1024}')
+              DISK_USED=$(df $PWD | awk 'NR==2 {printf "%.1f", $3/1024}')
+              DISK_TOTAL=$(df $PWD | awk 'NR==2 {printf "%.1f", $2/1024}')
+              echo "memory: ${MEM_USED}GB / ${MEM_TOTAL}GB | disk: ${DISK_USED}GB / ${DISK_TOTAL}GB"
+              sleep 3
+            done
+          }
+          monitor &
+          MONITOR_PID=$!
+
           # Ensure target/criterion directory exists
           mkdir -p target/criterion
 
@@ -94,6 +108,9 @@ jobs:
             echo "=== Threshold Check (5% significance) ===" >> bench_output.txt
             cargo bench --bench collection -- --baseline main --test 2>&1 | tee -a bench_output.txt || true
           fi
+
+          # Kill monitor
+          kill $MONITOR_PID || true
       - name: Upload benchmark reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -20,6 +20,8 @@ use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
 pub const NUM_POINTS: u64 = 100_000;
+/// Number of points to index in the benchmarks (indexing is slow and seems so can't afford to index all 100k points)
+pub const NUM_POINTS_INDEXING: u64 = 10_000;
 // Batch size for reading and writing (but not querying)
 pub const BATCH_SIZE: usize = 1000;
 // Number of queries to execute in total

--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -172,3 +172,8 @@ pub fn create_temp_db() -> (sled::Db, TempDir) {
 pub fn generate_integer_values(num_values: usize) -> Vec<i64> {
     (0..num_values).map(|i| i as i64 * 10).collect::<Vec<_>>()
 }
+
+/// Generates text values for benchmark storage
+pub fn generate_text_values(num_values: usize) -> Vec<String> {
+    (0..num_values).map(|i| format!("Hello world {}", i)).collect::<Vec<_>>()
+}

--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -155,7 +155,9 @@ pub fn benchmark_group<'a>(
     name: &str,
 ) -> BenchmarkGroup<'a, criterion::measurement::WallTime> {
     let mut group = c.benchmark_group(name);
-    group.sample_size(100); // Default is 100
+    group.sample_size(100); // default is 100
+    group.measurement_time(Duration::from_secs(5)); // default is 5s
+    group.warm_up_time(Duration::from_secs(3)); // default is 3s
     group.significance_level(0.05);
     group.noise_threshold(0.05);
     group
@@ -168,12 +170,16 @@ pub fn create_temp_db() -> (sled::Db, TempDir) {
     (db, tempdir)
 }
 
-/// Generates integer values for benchmark storage
-pub fn generate_integer_values(num_values: usize) -> Vec<i64> {
-    (0..num_values).map(|i| i as i64 * 10).collect::<Vec<_>>()
+/// Generates integer values for indexing benchmarks
+pub fn generate_integer_values(num_points: usize) -> Vec<Value> {
+    (0..num_points)
+        .map(|i| Value::Number((i as i64 * 10).into()))
+        .collect()
 }
 
-/// Generates text values for benchmark storage
-pub fn generate_text_values(num_values: usize) -> Vec<String> {
-    (0..num_values).map(|i| format!("Hello world {}", i)).collect::<Vec<_>>()
+/// Generates text values for indexing benchmarks
+pub fn generate_text_values(num_points: usize) -> Vec<Value> {
+    (0..num_points)
+        .map(|i| Value::String(format!("foo bar {}", i)))
+        .collect()
 }

--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -20,7 +20,7 @@ use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
 pub const NUM_POINTS: u64 = 100_000;
-/// Number of points to index in the benchmarks (indexing is slow and seems so can't afford to index all 100k points)
+/// Number of points to index in the benchmarks (payload indices can grow beyong the GH CI RAM so can't afford to index all 100k points)
 pub const NUM_POINTS_INDEXING: u64 = 10_000;
 // Batch size for reading and writing (but not querying)
 pub const BATCH_SIZE: usize = 1000;

--- a/benches/collection/index.rs
+++ b/benches/collection/index.rs
@@ -1,6 +1,10 @@
-use crate::common::{benchmark_group, create_temp_db, generate_integer_values, generate_text_values, BATCH_SIZE};
+use crate::common::{
+    benchmark_group, create_temp_db, generate_integer_values, generate_text_values, BATCH_SIZE,
+};
 use criterion::Criterion;
-use smoldb::storage::index::{integer::IntegerIndex, payload_index::FieldIndexTrait, text::TextIndex};
+use smoldb::storage::index::{
+    integer::IntegerIndex, payload_index::FieldIndexTrait, text::TextIndex,
+};
 
 // Todo: payload_index should have dedicated benches binary that's not part of collection benches?
 
@@ -20,10 +24,8 @@ pub fn int_indexing(c: &mut Criterion) {
         let index = IntegerIndex::open(&db, "price", false).unwrap();
 
         b.iter(|| {
-            // todo: Add batching when supported by integer index
-            for (point_id, value) in point_ids.iter().zip(values.iter()) {
-                index.add_point(*point_id, value).unwrap();
-            }
+            // todo: Add batching
+            index.add_points(&point_ids, &values).unwrap();
         });
     }
 
@@ -32,10 +34,8 @@ pub fn int_indexing(c: &mut Criterion) {
         let index_with_in_mem = IntegerIndex::open(&db, "price", true).unwrap();
 
         b.iter(|| {
-            // todo: Add batching when supported by integer index
-            for (point_id, value) in point_ids.iter().zip(values.iter()) {
-                index_with_in_mem.add_point(*point_id, value).unwrap();
-            }
+            // todo: Add batching
+            index_with_in_mem.add_points(&point_ids, &values).unwrap();
         });
     }
 }
@@ -56,10 +56,8 @@ pub fn text_indexing(c: &mut Criterion) {
         let index = TextIndex::open(&db, "description", false).unwrap();
 
         b.iter(|| {
-            // todo: Add batching when supported by integer index
-            for (point_id, value) in point_ids.iter().zip(values.iter()) {
-                index.add_point(*point_id, value).unwrap();
-            }
+            // todo: Add batching
+            index.add_points(&point_ids, &values).unwrap();
         });
     });
 
@@ -68,10 +66,8 @@ pub fn text_indexing(c: &mut Criterion) {
         let index_with_in_mem = TextIndex::open(&db, "description", true).unwrap();
 
         b.iter(|| {
-            // todo: Add batching when supported by integer index
-            for (point_id, value) in point_ids.iter().zip(values.iter()) {
-                index_with_in_mem.add_point(*point_id, value).unwrap();
-            }
+            // todo: Add batching
+            index_with_in_mem.add_points(&point_ids, &values).unwrap();
         });
     });
 }

--- a/benches/collection/index.rs
+++ b/benches/collection/index.rs
@@ -1,6 +1,7 @@
-use crate::common::{benchmark_group, create_temp_db, generate_integer_values, BATCH_SIZE};
+use crate::common::{benchmark_group, create_temp_db, generate_integer_values, generate_text_values, BATCH_SIZE};
 use criterion::Criterion;
-use smoldb::storage::index::integer::IntegerIndex;
+use serde_json::Value;
+use smoldb::storage::index::{integer::IntegerIndex, payload_index::FieldIndexTrait, text::TextIndex};
 
 // Todo: payload_index should have dedicated benches binary that's not part of collection benches?
 
@@ -42,4 +43,40 @@ pub fn int_indexing(c: &mut Criterion) {
             });
         });
     }
+}
+
+// Text index benchmarks
+
+pub fn text_indexing(c: &mut Criterion) {
+    let mut group = benchmark_group(c, "index/text");
+
+    // For now only upserting BATCH_SIZE points at a time, but must upsert NUM_POINTS points in future
+    // once indexing is faster due to batching.
+    let num_points = BATCH_SIZE as u64;
+    let point_ids: Vec<u64> = (0..num_points).collect();
+    let values = generate_text_values(num_points as usize);
+
+    group.bench_function("batch", |b| {
+        let (db, _tempdir) = create_temp_db();
+        let index = TextIndex::open(&db, "description", false).unwrap();
+
+        b.iter(|| {
+            // todo: Add batching when supported by integer index
+            for (point_id, value) in point_ids.iter().zip(values.iter()) {
+                index.add_point(*point_id, &Value::String(value.clone())).unwrap();
+            }
+        });
+    });
+
+    group.bench_function("in_memory/batch", |b| {
+        let (db, _tempdir) = create_temp_db();
+        let index_with_in_mem = TextIndex::open(&db, "description", true).unwrap();
+
+        b.iter(|| {
+            // todo: Add batching when supported by integer index
+            for (point_id, value) in point_ids.iter().zip(values.iter()) {
+                index_with_in_mem.add_point(*point_id, &Value::String(value.clone())).unwrap();
+            }
+        });
+    });
 }

--- a/benches/collection/index.rs
+++ b/benches/collection/index.rs
@@ -1,6 +1,5 @@
 use crate::common::{benchmark_group, create_temp_db, generate_integer_values, generate_text_values, BATCH_SIZE};
 use criterion::Criterion;
-use serde_json::Value;
 use smoldb::storage::index::{integer::IntegerIndex, payload_index::FieldIndexTrait, text::TextIndex};
 
 // Todo: payload_index should have dedicated benches binary that's not part of collection benches?
@@ -20,13 +19,11 @@ pub fn int_indexing(c: &mut Criterion) {
         let (db, _tempdir) = create_temp_db();
         let index = IntegerIndex::open(&db, "price", false).unwrap();
 
-        group.bench_function("batch", |b| {
-            b.iter(|| {
-                // todo: Add batching when supported by integer index
-                for (point_id, value) in point_ids.iter().zip(values.iter()) {
-                    index.upsert(*point_id, *value).unwrap();
-                }
-            });
+        b.iter(|| {
+            // todo: Add batching when supported by integer index
+            for (point_id, value) in point_ids.iter().zip(values.iter()) {
+                index.add_point(*point_id, value).unwrap();
+            }
         });
     }
 
@@ -34,13 +31,11 @@ pub fn int_indexing(c: &mut Criterion) {
         let (db, _tempdir) = create_temp_db();
         let index_with_in_mem = IntegerIndex::open(&db, "price", true).unwrap();
 
-        group.bench_function("in_memory/batch", |b| {
-            b.iter(|| {
-                // todo: Add batching when supported by integer index
-                for (point_id, value) in point_ids.iter().zip(values.iter()) {
-                    index_with_in_mem.upsert(*point_id, *value).unwrap();
-                }
-            });
+        b.iter(|| {
+            // todo: Add batching when supported by integer index
+            for (point_id, value) in point_ids.iter().zip(values.iter()) {
+                index_with_in_mem.add_point(*point_id, value).unwrap();
+            }
         });
     }
 }
@@ -63,7 +58,7 @@ pub fn text_indexing(c: &mut Criterion) {
         b.iter(|| {
             // todo: Add batching when supported by integer index
             for (point_id, value) in point_ids.iter().zip(values.iter()) {
-                index.add_point(*point_id, &Value::String(value.clone())).unwrap();
+                index.add_point(*point_id, value).unwrap();
             }
         });
     });
@@ -75,7 +70,7 @@ pub fn text_indexing(c: &mut Criterion) {
         b.iter(|| {
             // todo: Add batching when supported by integer index
             for (point_id, value) in point_ids.iter().zip(values.iter()) {
-                index_with_in_mem.add_point(*point_id, &Value::String(value.clone())).unwrap();
+                index_with_in_mem.add_point(*point_id, value).unwrap();
             }
         });
     });

--- a/benches/collection/index.rs
+++ b/benches/collection/index.rs
@@ -23,9 +23,11 @@ pub fn int_indexing(c: &mut Criterion) {
         let (db, _tempdir) = create_temp_db();
         let index = IntegerIndex::open(&db, "price", false).unwrap();
 
-        b.iter(|| {
-            // todo: Add batching
-            index.add_points(&point_ids, &values).unwrap();
+        group.bench_function("batch", |b| {
+            b.iter(|| {
+                // todo: Add batching
+                index.add_points(&point_ids, &values).unwrap();
+            });
         });
     }
 
@@ -33,9 +35,10 @@ pub fn int_indexing(c: &mut Criterion) {
         let (db, _tempdir) = create_temp_db();
         let index_with_in_mem = IntegerIndex::open(&db, "price", true).unwrap();
 
-        b.iter(|| {
-            // todo: Add batching
-            index_with_in_mem.add_points(&point_ids, &values).unwrap();
+        group.bench_function("in_memory/batch", |b| {
+            b.iter(|| {
+                index_with_in_mem.add_points(&point_ids, &values).unwrap();
+            });
         });
     }
 }

--- a/benches/collection/main.rs
+++ b/benches/collection/main.rs
@@ -10,6 +10,6 @@ use criterion::{criterion_group, criterion_main, Criterion};
 criterion_group!(
     name = benches;
     config = Criterion::default();
-    targets = write::write, read::read, query::int_query, text_search::text_query, index::int_indexing
+    targets = write::write, read::read, query::int_query, text_search::text_query, index::int_indexing, index::text_indexing
 );
 criterion_main!(benches);

--- a/benches/collection/query.rs
+++ b/benches/collection/query.rs
@@ -2,7 +2,8 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
-    create_tempdir, generate_int_queries, generate_points, CONCURRENCY, NUM_POINTS, NUM_QUERIES,
+    create_tempdir, generate_int_queries, generate_points, BATCH_SIZE, CONCURRENCY, NUM_POINTS,
+    NUM_POINTS_INDEXING, NUM_QUERIES,
 };
 use criterion::Criterion;
 use futures::stream::{self, StreamExt};
@@ -26,7 +27,7 @@ pub fn int_query(c: &mut Criterion) {
                 channel_service,
                 Some(payload_index),
                 generate_points(NUM_POINTS),
-                false,
+                true, // Wait for indexing
             )
             .await
         });
@@ -53,10 +54,12 @@ pub fn int_query(c: &mut Criterion) {
                 channel_service,
                 Some(payload_index),
                 generate_points(NUM_POINTS),
-                false,
+                true, // Wait for indexing
             )
             .await
         });
+
+        // ToDo: Ensure that all points have been indexed before querying?
 
         let collection_arc = Arc::new(collection);
 

--- a/benches/collection/query.rs
+++ b/benches/collection/query.rs
@@ -2,8 +2,8 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
-    create_tempdir, generate_int_queries, generate_points, BATCH_SIZE, CONCURRENCY, NUM_POINTS,
-    NUM_POINTS_INDEXING, NUM_QUERIES,
+    create_tempdir, generate_int_queries, generate_points, CONCURRENCY, NUM_POINTS_INDEXING,
+    NUM_QUERIES,
 };
 use criterion::Criterion;
 use futures::stream::{self, StreamExt};
@@ -27,7 +27,7 @@ pub fn int_query(c: &mut Criterion) {
                 channel_service,
                 Some(payload_index),
                 generate_points(NUM_POINTS),
-                true, // Wait for indexing
+                false, // Don't wait for indexing
             )
             .await
         });
@@ -54,7 +54,7 @@ pub fn int_query(c: &mut Criterion) {
                 channel_service,
                 Some(payload_index),
                 generate_points(NUM_POINTS),
-                true, // Wait for indexing
+                false, // Don't wait for indexing
             )
             .await
         });

--- a/benches/collection/query.rs
+++ b/benches/collection/query.rs
@@ -26,8 +26,8 @@ pub fn int_query(c: &mut Criterion) {
                 &tempdir,
                 channel_service,
                 Some(payload_index),
-                generate_points(NUM_POINTS),
-                false, // Don't wait for indexing
+                generate_points(NUM_POINTS_INDEXING),
+                true, // Wait for indexing
             )
             .await
         });
@@ -53,8 +53,8 @@ pub fn int_query(c: &mut Criterion) {
                 &tempdir,
                 channel_service,
                 Some(payload_index),
-                generate_points(NUM_POINTS),
-                false, // Don't wait for indexing
+                generate_points(NUM_POINTS_INDEXING),
+                true, // Wait for indexing
             )
             .await
         });

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -25,7 +25,7 @@ pub fn text_query(c: &mut Criterion) {
                 &tempdir,
                 channel_service,
                 Some(payload_index),
-                generate_points(NUM_POINTS),
+                generate_points(NUM_POINTS_INDEXING),
                 true, // Wait for indexing to complete
             )
             .await
@@ -51,7 +51,7 @@ pub fn text_query(c: &mut Criterion) {
                 &tempdir,
                 channel_service,
                 Some(payload_index),
-                generate_points(NUM_POINTS),
+                generate_points(NUM_POINTS_INDEXING),
                 true, // Wait for indexing to complete
             )
             .await

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -26,7 +26,7 @@ pub fn text_query(c: &mut Criterion) {
                 channel_service,
                 Some(payload_index),
                 generate_points(NUM_POINTS),
-                false,
+                true, // Wait for indexing to complete
             )
             .await
         });
@@ -52,10 +52,13 @@ pub fn text_query(c: &mut Criterion) {
                 channel_service,
                 Some(payload_index),
                 generate_points(NUM_POINTS),
-                false,
+                true, // Wait for indexing to complete
             )
             .await
         });
+
+        // ToDo: Ensure that all points have been indexed before querying?
+
         let collection_arc = Arc::new(collection);
 
         // For querying, batch size is always 1 (for now)

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -2,8 +2,8 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
-    create_tempdir, generate_points, generate_text_queries, CONCURRENCY, NUM_POINTS_INDEXING, NUM_QUERIES,
-    TEXT_FIELD,
+    create_tempdir, generate_points, generate_text_queries, CONCURRENCY, NUM_POINTS_INDEXING,
+    NUM_QUERIES, TEXT_FIELD,
 };
 use criterion::{Criterion, Throughput};
 use futures::stream::{self, StreamExt};

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
-    create_tempdir, generate_points, generate_text_queries, CONCURRENCY, NUM_POINTS, NUM_QUERIES,
+    create_tempdir, generate_points, generate_text_queries, CONCURRENCY, NUM_POINTS_INDEXING, NUM_QUERIES,
     TEXT_FIELD,
 };
 use criterion::{Criterion, Throughput};

--- a/src/storage/replicas/local_shard.rs
+++ b/src/storage/replicas/local_shard.rs
@@ -81,8 +81,8 @@ impl LocalShard {
 
             rt.block_on(async {
                 if let Err(e) = segment.run_indexing_loop().await {
-                    log::error!("Indexing loop error for segment {}: {}", segment_id, e); // for general logs
-                    eprintln!("Indexing loop error for segment {}: {}", segment_id, e);
+                    log::error!("Indexing loop crashed for segment {}: {}", segment_id, e); // for general logs
+                    eprintln!("Indexing loop crashed for segment {}: {}", segment_id, e);
                     // for benches with --nocapture
                 }
             });

--- a/src/storage/replicas/local_shard.rs
+++ b/src/storage/replicas/local_shard.rs
@@ -23,7 +23,7 @@ pub struct LocalShard {
     pub path: PathBuf,
     pub segments: HashMap<SegmentId, Arc<Segment>>,
     pub shard_state: ShardState,
-    _indexing_threads: HashMap<SegmentId, JoinHandle<()>>,
+    pub(crate) _indexing_threads: HashMap<SegmentId, JoinHandle<()>>,
     // ToDo: Wal
 }
 
@@ -182,5 +182,32 @@ impl LocalShard {
             .values()
             .filter_map(|segment| segment.indexing_queue_length().ok())
             .sum()
+    }
+}
+
+impl Drop for LocalShard {
+    fn drop(&mut self) {
+        // Signal all segments to shutdown their indexing loops
+        for segment in self.segments.values() {
+            segment.shutdown();
+        }
+
+        // Join all indexing threads to ensure they complete
+        // We need to take ownership of the threads, so we'll use a temporary HashMap
+        let mut threads = std::mem::take(&mut self._indexing_threads);
+        for (segment_id, handle) in threads.drain() {
+            if let Err(e) = handle.join() {
+                log::error!(
+                    "Failed to join indexing thread for segment {}: {:?}",
+                    segment_id,
+                    e
+                );
+            } else {
+                log::debug!(
+                    "Successfully joined indexing thread for segment {}",
+                    segment_id
+                );
+            }
+        }
     }
 }

--- a/src/storage/segment/mod.rs
+++ b/src/storage/segment/mod.rs
@@ -10,7 +10,10 @@ use futures::StreamExt;
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
-    sync::Mutex,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
     time::Instant,
 };
 
@@ -25,6 +28,7 @@ pub struct Segment {
     // ID tracker is valuable for building immutable segments, so same point can exist in multiple segments while only the latest version is visible
     pub payload_index: PayloadIndex,
     pub indexing_queue: Mutex<Vec<PointId>>,
+    pub shutdown_flag: Arc<AtomicBool>,
 }
 
 impl Segment {
@@ -53,6 +57,7 @@ impl Segment {
             db,
             payload_index,
             indexing_queue: Mutex::new(Vec::new()),
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -71,6 +76,7 @@ impl Segment {
             db,
             payload_index,
             indexing_queue: Mutex::new(Vec::new()),
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -204,6 +210,11 @@ impl Segment {
         Ok(queue.len())
     }
 
+    /// Signals the indexing loop to shutdown
+    pub fn shutdown(&self) {
+        self.shutdown_flag.store(true, Ordering::Release);
+    }
+
     /// Runs the background indexing loop, batching points efficiently.
     pub async fn run_indexing_loop(&self) -> StorageResult<()> {
         const INDEXING_THRESHOLD: usize = 100;
@@ -214,10 +225,21 @@ impl Segment {
         let mut last_index_time = Instant::now();
 
         loop {
+            // Check shutdown flag
+            if self.shutdown_flag.load(Ordering::Acquire) {
+                log::info!("Indexing loop shutting down");
+                break;
+            }
+
             // Fill the batch up to threshold or until interval passes.
             while point_ids.len() < INDEXING_THRESHOLD
                 && last_index_time.elapsed().as_millis() < INDEXING_INTERVAL_MS as u128
             {
+                // Check shutdown flag during batching
+                if self.shutdown_flag.load(Ordering::Acquire) {
+                    break;
+                }
+
                 let point_id_opt = {
                     let mut queue = self.indexing_queue.lock().map_err(|e| {
                         StorageError::ServiceError(format!(
@@ -247,6 +269,8 @@ impl Segment {
 
             last_index_time = Instant::now();
         }
+
+        Ok(())
     }
 
     // todo: Allow updating payload index schema on the fly


### PR DESCRIPTION
Must keep track of the indexing benchmarks since now we can do it in bulk.

Need this to track how much does parallelization help

Run with: `cargo bench --bench collection index_batch`

TODO:
- [ ] Investigate memory leak during benches when I do `cargo bench --bench collection`. It's still not resolved despite adding a `shutdown_flag` https://github.com/KShivendu/smoldb/issues/103

Lessons:
- If you spawn a thread that's not part of any runtime, and that thread takes a Arc<Struct>, and runs infinite loop, this `Struct` might survive even after the parent has been dropped until the entire process (not just tokio runtime) is killed.

<img width="1020" height="527" alt="image" src="https://github.com/user-attachments/assets/fd1c21ab-e65b-4bf5-9873-64241efa63be" />
