### PR TITLE
Refactor benches concurrent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ default = []
 
 [profile.bench]
 debug = true
+strip = false
+lto = false
 
 [[bench]]
 name = "collection"

--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -75,6 +75,22 @@ pub fn generate_points(num_points: u64) -> Vec<Point> {
         .collect()
 }
 
+/// todo: not used in the benchmarks yet
+/// Generates a random point with a random ID and payload
+#[allow(dead_code)]
+pub fn generate_random_points(num_points: usize) -> Vec<Point> {
+    (0..num_points)
+        .map(|_| {
+            let id = rand::random_range(0..NUM_POINTS);
+            let payload = json!({ "msg": format!("Hello world {}", id), "price": id as i64 * 10 });
+            Point {
+                id: PointId::Id(id),
+                payload,
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
 /// Generate queries for integer index
 pub fn generate_int_queries(num_queries: usize) -> Vec<Query> {
     (0..num_queries)
@@ -118,8 +134,20 @@ pub fn benchmark_group<'a>(
     name: &str,
 ) -> BenchmarkGroup<'a, criterion::measurement::WallTime> {
     let mut group = c.benchmark_group(name);
-    group.sample_size(20);
+    group.sample_size(100); // Default is 100
     group.significance_level(0.05);
     group.noise_threshold(0.05);
     group
+}
+
+/// Creates a temporary database for benchmark storage
+pub fn create_temp_db() -> (sled::Db, TempDir) {
+    let tempdir = create_tempdir();
+    let db = sled::open(tempdir.path()).unwrap();
+    (db, tempdir)
+}
+
+/// Generates integer values for benchmark storage
+pub fn generate_integer_values(num_values: usize) -> Vec<i64> {
+    (0..num_values).map(|i| i as i64 * 10).collect::<Vec<_>>()
 }

--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -3,6 +3,10 @@ use std::{collections::BTreeMap, sync::Arc};
 use criterion::BenchmarkGroup;
 use criterion::Criterion;
 use serde_json::json;
+use serde_json::Value;
+use smoldb::api::points::Query;
+use smoldb::storage::index::filter::FilterOperator;
+use smoldb::storage::index::filter::QueryFilter;
 use smoldb::{
     channel_service::ChannelService,
     storage::{
@@ -13,6 +17,13 @@ use smoldb::{
 };
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
+
+pub const NUM_POINTS: u64 = 100_000;
+// Batch size for reading and writing (but not querying)
+pub const BATCH_SIZE: usize = 1000;
+// Number of queries to execute in total
+pub const NUM_QUERIES: usize = 1000;
+pub const CONCURRENCY: usize = 16;
 
 /// Creates a new multi-threaded tokio runtime for benchmarks
 pub fn create_runtime() -> Runtime {
@@ -62,6 +73,30 @@ pub fn generate_points(num_points: u64) -> Vec<Point> {
             payload: json!({ "msg": format!("Hello world {}", id), "price": id as i64 * 10 }),
         })
         .collect()
+}
+
+/// Generate queries for integer index
+pub fn generate_int_queries(num_queries: usize) -> Vec<Query> {
+    (0..num_queries)
+        .map(|i| Query {
+            filter: QueryFilter::new("price", Value::from(i * 10), FilterOperator::Gte),
+            limit: Some(10),
+        })
+        .collect::<Vec<_>>()
+}
+
+/// Generate queries for text index
+pub fn generate_text_queries(num_queries: usize) -> Vec<Query> {
+    (0..num_queries)
+        .map(|i| Query {
+            filter: QueryFilter::new(
+                "text",
+                Value::from(format!("Hello world {}", i)),
+                FilterOperator::Eq,
+            ),
+            limit: Some(10),
+        })
+        .collect::<Vec<_>>()
 }
 
 /// Creates a collection and initializes it with the given points

--- a/benches/collection/index.rs
+++ b/benches/collection/index.rs
@@ -1,0 +1,41 @@
+use crate::common::{benchmark_group, create_temp_db, generate_integer_values, BATCH_SIZE};
+use criterion::Criterion;
+use smoldb::storage::index::integer::IntegerIndex;
+
+// Todo: payload_index should have dedicated benches binary that's not part of collection benches?
+
+// Integer index benchmarks
+
+pub fn int_indexing(c: &mut Criterion) {
+    let mut group = benchmark_group(c, "Bulk indexing (integer index)");
+
+    // For now only upserting BATCH_SIZE points at a time, but must upsert NUM_POINTS points in future
+    // once indexing is faster due to batching.
+    let num_points = BATCH_SIZE as u64;
+    let point_ids: Vec<u64> = (0..num_points).collect();
+    let values = generate_integer_values(num_points as usize);
+
+    group.bench_function("integer_index/batch", |b| {
+        let (db, _tempdir) = create_temp_db();
+        let index = IntegerIndex::open(&db, "price", false).unwrap();
+
+        b.iter(|| {
+            // todo: Add batching when supported by integer index
+            for (point_id, value) in point_ids.iter().zip(values.iter()) {
+                index.upsert(*point_id, *value).unwrap();
+            }
+        });
+    });
+
+    group.bench_function("integer_index/in_memory/batch", |b| {
+        let (db, _tempdir) = create_temp_db();
+        let index_with_in_mem = IntegerIndex::open(&db, "price", true).unwrap();
+
+        b.iter(|| {
+            // todo: Add batching when supported by integer index
+            for (point_id, value) in point_ids.iter().zip(values.iter()) {
+                index_with_in_mem.upsert(*point_id, *value).unwrap();
+            }
+        });
+    });
+}

--- a/benches/collection/index.rs
+++ b/benches/collection/index.rs
@@ -7,7 +7,7 @@ use smoldb::storage::index::integer::IntegerIndex;
 // Integer index benchmarks
 
 pub fn int_indexing(c: &mut Criterion) {
-    let mut group = benchmark_group(c, "Bulk indexing (integer index)");
+    let mut group = benchmark_group(c, "index/int");
 
     // For now only upserting BATCH_SIZE points at a time, but must upsert NUM_POINTS points in future
     // once indexing is faster due to batching.
@@ -15,7 +15,7 @@ pub fn int_indexing(c: &mut Criterion) {
     let point_ids: Vec<u64> = (0..num_points).collect();
     let values = generate_integer_values(num_points as usize);
 
-    group.bench_function("integer_index/batch", |b| {
+    group.bench_function("batch", |b| {
         let (db, _tempdir) = create_temp_db();
         let index = IntegerIndex::open(&db, "price", false).unwrap();
 
@@ -27,7 +27,7 @@ pub fn int_indexing(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("integer_index/in_memory/batch", |b| {
+    group.bench_function("in_memory/batch", |b| {
         let (db, _tempdir) = create_temp_db();
         let index_with_in_mem = IntegerIndex::open(&db, "price", true).unwrap();
 

--- a/benches/collection/main.rs
+++ b/benches/collection/main.rs
@@ -14,7 +14,6 @@ criterion_group!(
     read::concurrent_read,
     query::single_query,
     query::concurrent_query,
-    text_search::single_text_query,
-    text_search::concurrent_text_query
+    text_search::text_query_benchmarks
 );
 criterion_main!(benches);

--- a/benches/collection/main.rs
+++ b/benches/collection/main.rs
@@ -1,4 +1,5 @@
 mod common;
+mod index;
 mod query;
 mod read;
 mod text_search;
@@ -9,6 +10,6 @@ use criterion::{criterion_group, criterion_main, Criterion};
 criterion_group!(
     name = benches;
     config = Criterion::default();
-    targets = write::write, read::read, query::int_query, text_search::text_query
+    targets = write::write, read::read, query::int_query, text_search::text_query, index::int_indexing
 );
 criterion_main!(benches);

--- a/benches/collection/main.rs
+++ b/benches/collection/main.rs
@@ -4,16 +4,11 @@ mod read;
 mod text_search;
 mod write;
 
-use criterion::{criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 criterion_group!(
-    benches,
-    write::single_write,
-    write::concurrent_write,
-    read::single_read,
-    read::concurrent_read,
-    query::single_query,
-    query::concurrent_query,
-    text_search::text_query_benchmarks
+    name = benches;
+    config = Criterion::default();
+    targets = write::write, read::read, query::int_query, text_search::text_query
 );
 criterion_main!(benches);

--- a/benches/collection/query.rs
+++ b/benches/collection/query.rs
@@ -1,35 +1,25 @@
 use std::{collections::BTreeMap, sync::Arc};
 
+use crate::common::{
+    benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
+    create_tempdir, generate_int_queries, generate_points, CONCURRENCY, NUM_POINTS, NUM_QUERIES,
+};
 use criterion::{BatchSize, Criterion};
 use futures::{
     executor::block_on,
     stream::{self, StreamExt},
 };
-use serde_json::Value;
-
-use crate::common::{
-    benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
-    create_tempdir, generate_points,
-};
-use smoldb::{
-    api::points::Query,
-    storage::index::{
-        filter::{FilterOperator, QueryFilter},
-        payload_index::IndexConfig,
-    },
-};
+use smoldb::storage::index::payload_index::IndexConfig;
 
 pub fn int_query(c: &mut Criterion) {
     let mut group = benchmark_group(c, "query/int");
 
     // Perf when bench was first implemented: 31.807 µs
+    // Query a single point while there are NUM_POINTS points in the collection
     group.bench_function("single", |b| {
-        let query = Query {
-            filter: QueryFilter::new("price", Value::from(0), FilterOperator::Gte),
-            limit: Some(10),
-        };
         let rt = create_runtime();
         let setup = move || {
+            let query = generate_int_queries(1).first().unwrap().clone();
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
             let collection = block_on(async {
@@ -38,11 +28,11 @@ pub fn int_query(c: &mut Criterion) {
                     &tempdir,
                     channel_service,
                     Some(payload_index),
-                    generate_points(1), // todo: Should have 100_000 points but query only for a single point
+                    generate_points(NUM_POINTS),
                 )
                 .await
             });
-            (Arc::new(collection), query.clone())
+            (Arc::new(collection), query)
         };
         b.to_async(&rt).iter_batched(
             setup,
@@ -53,54 +43,42 @@ pub fn int_query(c: &mut Criterion) {
         );
     });
 
+    // ToDo: Query a single batch of RW_BATCH_SIZE points while there are NUM_POINTS points in the collection
+    // It needs support from the API to pass a batch of queries
+
     // Perf when bench was first implemented: 668.48 µs
-    group.bench_function("concurrent", |b| {
+    // For querying, batch size is always 1 (for now)
+    // So we can just run num_queries queries in CONCURRENCY parallel with batch size=1
+    group.bench_function("concurrent", |b: &mut criterion::Bencher<'_>| {
         let rt = create_runtime();
-        let num_points = 100_000;
-        let num_threads = 4;
-        let chunk_size = (num_points / num_threads) as usize;
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
-            let points = generate_points(num_points);
             let collection = block_on(async {
                 let payload_index = BTreeMap::from_iter([("price".to_string(), IndexConfig::Int)]);
                 create_collection_with_points(
                     &tempdir,
                     channel_service,
                     Some(payload_index),
-                    points,
+                    generate_points(NUM_POINTS),
                 )
                 .await
             });
             let collection_arc = Arc::new(collection);
 
-            // Create queries for different chunks - filtering on different message values
-            let queries: Vec<Query> = (0..num_threads)
-                .map(|i| {
-                    let start_id = i * chunk_size as u64;
-                    Query {
-                        filter: QueryFilter::new(
-                            "price",
-                            Value::from(start_id * 10),
-                            FilterOperator::Gte,
-                        ),
-                        limit: Some(10),
-                    }
-                })
-                .collect();
-
-            (collection_arc, queries, num_threads)
+            // Create queries for different chunks
+            let queries = generate_int_queries(NUM_QUERIES);
+            (collection_arc, queries)
         };
         b.to_async(&rt).iter_batched(
             setup,
-            |(collection_arc, queries, num_threads)| async move {
+            |(collection_arc, queries)| async move {
                 stream::iter(queries)
                     .map(|query| {
                         let collection_clone = collection_arc.clone();
                         async move { collection_clone.query_points(query, true).await.unwrap() }
                     })
-                    .buffer_unordered(num_threads as usize)
+                    .buffer_unordered(CONCURRENCY)
                     .collect::<Vec<_>>()
                     .await;
             },

--- a/benches/collection/query.rs
+++ b/benches/collection/query.rs
@@ -19,19 +19,16 @@ use smoldb::{
     },
 };
 
-// Perf when bench was first implemented: 31.807 µs
-pub fn single_query(c: &mut Criterion) {
-    let mut group = benchmark_group(c, "Single query benchmarks");
+pub fn int_query(c: &mut Criterion) {
+    let mut group = benchmark_group(c, "query/int");
 
-    let rt = create_runtime();
-
-    let query = Query {
-        filter: QueryFilter::new("price", Value::from(0), FilterOperator::Gte),
-        limit: Some(10),
-    };
-
-    group.bench_function("single_query", |b| {
-        let query = query.clone();
+    // Perf when bench was first implemented: 31.807 µs
+    group.bench_function("single", |b| {
+        let query = Query {
+            filter: QueryFilter::new("price", Value::from(0), FilterOperator::Gte),
+            limit: Some(10),
+        };
+        let rt = create_runtime();
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
@@ -55,23 +52,13 @@ pub fn single_query(c: &mut Criterion) {
             BatchSize::PerIteration,
         );
     });
-}
 
-// Perf when bench was first implemented: 668.48 µs
-pub fn concurrent_query(c: &mut Criterion) {
-    let mut group = benchmark_group(c, "Concurrent query benchmarks");
-
-    let rt = create_runtime();
-    let rt_handle = rt.handle().clone();
-    let num_points = 100_000;
-    let num_threads = 4;
-    let chunk_size = (num_points / num_threads) as usize;
-
-    group.bench_function("concurrent_query", |b| {
-        let rt_handle = rt_handle.clone();
-        let num_points = num_points;
-        let num_threads = num_threads;
-        let chunk_size = chunk_size;
+    // Perf when bench was first implemented: 668.48 µs
+    group.bench_function("concurrent", |b| {
+        let rt = create_runtime();
+        let num_points = 100_000;
+        let num_threads = 4;
+        let chunk_size = (num_points / num_threads) as usize;
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();

--- a/benches/collection/query.rs
+++ b/benches/collection/query.rs
@@ -4,7 +4,7 @@ use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
     create_tempdir, generate_int_queries, generate_points, CONCURRENCY, NUM_POINTS, NUM_QUERIES,
 };
-use criterion::{BatchSize, Criterion};
+use criterion::Criterion;
 use futures::{
     executor::block_on,
     stream::{self, StreamExt},
@@ -18,29 +18,22 @@ pub fn int_query(c: &mut Criterion) {
     // Query a single point while there are NUM_POINTS points in the collection
     group.bench_function("single", |b| {
         let rt = create_runtime();
-        let setup = move || {
-            let query = generate_int_queries(1).first().unwrap().clone();
-            let tempdir = create_tempdir();
-            let channel_service = create_channel_service();
-            let collection = block_on(async {
-                let payload_index = BTreeMap::from_iter([("price".to_string(), IndexConfig::Int)]);
-                create_collection_with_points(
-                    &tempdir,
-                    channel_service,
-                    Some(payload_index),
-                    generate_points(NUM_POINTS),
-                )
-                .await
-            });
-            (Arc::new(collection), query)
-        };
-        b.to_async(&rt).iter_batched(
-            setup,
-            move |(collection_arc, query)| async move {
-                collection_arc.query_points(query, true).await.unwrap();
-            },
-            BatchSize::PerIteration,
-        );
+        let query = generate_int_queries(1).first().unwrap().clone();
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let collection = block_on(async {
+            let payload_index = BTreeMap::from_iter([("price".to_string(), IndexConfig::Int)]);
+            create_collection_with_points(
+                &tempdir,
+                channel_service,
+                Some(payload_index),
+                generate_points(NUM_POINTS),
+            )
+            .await
+        });
+        b.to_async(&rt).iter(|| async {
+            collection.query_points(query.clone(), true).await.unwrap();
+        });
     });
 
     // ToDo: Query a single batch of RW_BATCH_SIZE points while there are NUM_POINTS points in the collection
@@ -51,38 +44,34 @@ pub fn int_query(c: &mut Criterion) {
     // So we can just run num_queries queries in CONCURRENCY parallel with batch size=1
     group.bench_function("concurrent", |b: &mut criterion::Bencher<'_>| {
         let rt = create_runtime();
-        let setup = move || {
-            let tempdir = create_tempdir();
-            let channel_service = create_channel_service();
-            let collection = block_on(async {
-                let payload_index = BTreeMap::from_iter([("price".to_string(), IndexConfig::Int)]);
-                create_collection_with_points(
-                    &tempdir,
-                    channel_service,
-                    Some(payload_index),
-                    generate_points(NUM_POINTS),
-                )
-                .await
-            });
-            let collection_arc = Arc::new(collection);
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let collection = block_on(async {
+            let payload_index = BTreeMap::from_iter([("price".to_string(), IndexConfig::Int)]);
+            create_collection_with_points(
+                &tempdir,
+                channel_service,
+                Some(payload_index),
+                generate_points(NUM_POINTS),
+            )
+            .await
+        });
 
-            // Create queries for different chunks
-            let queries = generate_int_queries(NUM_QUERIES);
-            (collection_arc, queries)
-        };
-        b.to_async(&rt).iter_batched(
-            setup,
-            |(collection_arc, queries)| async move {
-                stream::iter(queries)
-                    .map(|query| {
-                        let collection_clone = collection_arc.clone();
-                        async move { collection_clone.query_points(query, true).await.unwrap() }
-                    })
-                    .buffer_unordered(CONCURRENCY)
-                    .collect::<Vec<_>>()
-                    .await;
-            },
-            BatchSize::PerIteration,
-        );
+        let collection_arc = Arc::new(collection);
+
+        // Create queries for different chunks
+        let queries = generate_int_queries(NUM_QUERIES);
+
+        b.to_async(&rt).iter(|| async {
+            let queries = queries.clone();
+            stream::iter(queries)
+                .map(|query| {
+                    let collection_clone = collection_arc.clone();
+                    async move { collection_clone.query_points(query, true).await.unwrap() }
+                })
+                .buffer_unordered(CONCURRENCY)
+                .collect::<Vec<_>>()
+                .await;
+        });
     });
 }

--- a/benches/collection/query.rs
+++ b/benches/collection/query.rs
@@ -1,6 +1,10 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use criterion::Criterion;
+use criterion::{BatchSize, Criterion};
+use futures::{
+    executor::block_on,
+    stream::{self, StreamExt},
+};
 use serde_json::Value;
 
 use crate::common::{
@@ -20,20 +24,6 @@ pub fn single_query(c: &mut Criterion) {
     let mut group = benchmark_group(c, "Single query benchmarks");
 
     let rt = create_runtime();
-    let tempdir = create_tempdir();
-    let channel_service = create_channel_service();
-
-    let collection = rt.block_on(async {
-        let payload_index = BTreeMap::from_iter([("price".to_string(), IndexConfig::Int)]);
-        create_collection_with_points(
-            &tempdir,
-            channel_service,
-            Some(payload_index),
-            generate_points(1), // todo: Should have 100_000 points but query only for a single point
-        )
-        .await
-    });
-    let collection_arc = Arc::new(collection);
 
     let query = Query {
         filter: QueryFilter::new("price", Value::from(0), FilterOperator::Gte),
@@ -41,12 +31,29 @@ pub fn single_query(c: &mut Criterion) {
     };
 
     group.bench_function("single_query", |b| {
-        b.to_async(&rt).iter(|| async {
-            collection_arc
-                .query_points(query.clone(), true)
+        let query = query.clone();
+        let setup = move || {
+            let tempdir = create_tempdir();
+            let channel_service = create_channel_service();
+            let collection = block_on(async {
+                let payload_index = BTreeMap::from_iter([("price".to_string(), IndexConfig::Int)]);
+                create_collection_with_points(
+                    &tempdir,
+                    channel_service,
+                    Some(payload_index),
+                    generate_points(1), // todo: Should have 100_000 points but query only for a single point
+                )
                 .await
-                .unwrap();
-        })
+            });
+            (Arc::new(collection), query.clone())
+        };
+        b.to_async(&rt).iter_batched(
+            setup,
+            move |(collection_arc, query)| async move {
+                collection_arc.query_points(query, true).await.unwrap();
+            },
+            BatchSize::PerIteration,
+        );
     });
 }
 
@@ -55,41 +62,62 @@ pub fn concurrent_query(c: &mut Criterion) {
     let mut group = benchmark_group(c, "Concurrent query benchmarks");
 
     let rt = create_runtime();
-    let tempdir = create_tempdir();
-
+    let rt_handle = rt.handle().clone();
     let num_points = 100_000;
     let num_threads = 4;
     let chunk_size = (num_points / num_threads) as usize;
 
-    let points = generate_points(num_points);
-
-    let channel_service = create_channel_service();
-
-    let collection = rt.block_on(async {
-        let payload_index = BTreeMap::from_iter([("price".to_string(), IndexConfig::Int)]);
-        create_collection_with_points(&tempdir, channel_service, Some(payload_index), points).await
-    });
-    let collection_arc = Arc::new(collection);
-
-    // Create queries for different chunks - filtering on different message values
-    let queries: Vec<Query> = (0..num_threads)
-        .map(|i| {
-            let start_id = i * chunk_size as u64;
-            Query {
-                filter: QueryFilter::new("price", Value::from(start_id * 10), FilterOperator::Gte),
-                limit: Some(10),
-            }
-        })
-        .collect();
-
     group.bench_function("concurrent_query", |b| {
-        b.to_async(&rt).iter(|| async {
-            for query in &queries {
-                collection_arc
-                    .query_points(query.clone(), true)
-                    .await
-                    .unwrap();
-            }
-        })
+        let rt_handle = rt_handle.clone();
+        let num_points = num_points;
+        let num_threads = num_threads;
+        let chunk_size = chunk_size;
+        let setup = move || {
+            let tempdir = create_tempdir();
+            let channel_service = create_channel_service();
+            let points = generate_points(num_points);
+            let collection = block_on(async {
+                let payload_index = BTreeMap::from_iter([("price".to_string(), IndexConfig::Int)]);
+                create_collection_with_points(
+                    &tempdir,
+                    channel_service,
+                    Some(payload_index),
+                    points,
+                )
+                .await
+            });
+            let collection_arc = Arc::new(collection);
+
+            // Create queries for different chunks - filtering on different message values
+            let queries: Vec<Query> = (0..num_threads)
+                .map(|i| {
+                    let start_id = i * chunk_size as u64;
+                    Query {
+                        filter: QueryFilter::new(
+                            "price",
+                            Value::from(start_id * 10),
+                            FilterOperator::Gte,
+                        ),
+                        limit: Some(10),
+                    }
+                })
+                .collect();
+
+            (collection_arc, queries, num_threads)
+        };
+        b.to_async(&rt).iter_batched(
+            setup,
+            |(collection_arc, queries, num_threads)| async move {
+                stream::iter(queries)
+                    .map(|query| {
+                        let collection_clone = collection_arc.clone();
+                        async move { collection_clone.query_points(query, true).await.unwrap() }
+                    })
+                    .buffer_unordered(num_threads as usize)
+                    .collect::<Vec<_>>()
+                    .await;
+            },
+            BatchSize::PerIteration,
+        );
     });
 }

--- a/benches/collection/read.rs
+++ b/benches/collection/read.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use criterion::{BatchSize, Criterion, Throughput};
+use criterion::{Criterion, Throughput};
 use futures::{
     executor::block_on,
     stream::{self, StreamExt},
@@ -61,7 +61,7 @@ pub fn read(c: &mut Criterion) {
 
         b.to_async(&rt).iter(|| async {
             collection
-                .read_points(Some(read_batch), None, true)
+                .read_points(Some(read_batch.clone()), None, true)
                 .await
                 .unwrap();
         });

--- a/benches/collection/read.rs
+++ b/benches/collection/read.rs
@@ -81,7 +81,7 @@ pub fn read(c: &mut Criterion) {
     // Perf in the beginning: ???
     // Perf with hashring and tokio: 124.54ms (100_000 points, 4 threads, 2 shards; only 170x slower than single read)
     // Read NUM_POINTS points in NUM_THREADS parallel batches of BATCH_SIZE points
-    group.throughput(Throughput::Elements(NUM_POINTS as u64));
+    group.throughput(Throughput::Elements(NUM_POINTS));
     group.bench_function("concurrent", |b| {
         let rt = create_runtime();
 

--- a/benches/collection/read.rs
+++ b/benches/collection/read.rs
@@ -1,14 +1,15 @@
 use std::sync::Arc;
 
-use criterion::{BatchSize, Criterion};
+use criterion::{BatchSize, Criterion, Throughput};
 use futures::{
     executor::block_on,
     stream::{self, StreamExt},
 };
+use smoldb::storage::segment::PointId;
 
 use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
-    create_tempdir, generate_points,
+    create_tempdir, generate_points, BATCH_SIZE, CONCURRENCY, NUM_POINTS,
 };
 
 pub fn read(c: &mut Criterion) {
@@ -16,25 +17,60 @@ pub fn read(c: &mut Criterion) {
 
     // Perf in the beginning: ???
     // Perf with hashring and tokio: 729.73 ns
+    // Read a single point when there are NUM_POINTS points in the collection
     group.bench_function("single", |b| {
         let rt = create_runtime();
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
             block_on(async {
-                create_collection_with_points(&tempdir, channel_service, None, generate_points(1))
-                    .await
+                create_collection_with_points(
+                    &tempdir,
+                    channel_service,
+                    None,
+                    generate_points(NUM_POINTS), // insert many points but query only for the last one
+                )
+                .await
             })
         };
         b.to_async(&rt).iter_batched(
             setup,
             |collection| async move {
                 collection
-                    .read_points(
-                        Some(vec![smoldb::storage::segment::PointId::Id(0)]),
-                        None,
-                        true,
-                    )
+                    .read_points(Some(vec![PointId::Id(NUM_POINTS - 1)]), None, true)
+                    .await
+                    .unwrap();
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    // Read 1 batch of BATCH_SIZE points while there are NUM_POINTS points in the collection
+    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+    group.bench_function("batch", |b| {
+        let rt = create_runtime();
+        let setup = move || {
+            let tempdir = create_tempdir();
+            let channel_service = create_channel_service();
+            let collection = block_on(async {
+                create_collection_with_points(
+                    &tempdir,
+                    channel_service,
+                    None,
+                    generate_points(NUM_POINTS),
+                )
+                .await
+            });
+            let read_batch = (0..BATCH_SIZE)
+                .map(|i| PointId::Id(i as u64))
+                .collect::<Vec<_>>();
+            (collection, read_batch)
+        };
+        b.to_async(&rt).iter_batched(
+            setup,
+            |(collection, read_batch)| async move {
+                collection
+                    .read_points(Some(read_batch), None, true)
                     .await
                     .unwrap();
             },
@@ -44,26 +80,25 @@ pub fn read(c: &mut Criterion) {
 
     // Perf in the beginning: ???
     // Perf with hashring and tokio: 124.54ms (100_000 points, 4 threads, 2 shards; only 170x slower than single read)
+    // Read NUM_POINTS points in NUM_THREADS parallel batches of BATCH_SIZE points
+    group.throughput(Throughput::Elements(NUM_POINTS as u64));
     group.bench_function("concurrent", |b| {
         let rt = create_runtime();
-        let num_points = 100_000;
-        let num_threads = 4;
-        let chunk_size = (num_points / num_threads) as usize;
 
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
-            let points = generate_points(num_points);
-            let point_ids = points.iter().map(|p| p.id.clone()).collect::<Vec<_>>();
+            let points = generate_points(NUM_POINTS);
+            let all_point_ids = points.iter().map(|p| p.id.clone()).collect::<Vec<_>>();
             let collection = block_on(async {
                 create_collection_with_points(&tempdir, channel_service, None, points).await
             });
-            (Arc::new(collection), point_ids, chunk_size, num_threads)
+            (Arc::new(collection), all_point_ids)
         };
         b.to_async(&rt).iter_batched(
             setup,
-            |(collection, point_ids, chunk_size, num_threads)| async move {
-                stream::iter(point_ids.chunks(chunk_size))
+            |(collection, all_point_ids)| async move {
+                stream::iter(all_point_ids.chunks(BATCH_SIZE))
                     .map(|chunk| {
                         let collection_clone = collection.clone();
                         let chunk = chunk.to_vec();
@@ -74,7 +109,7 @@ pub fn read(c: &mut Criterion) {
                                 .unwrap()
                         }
                     })
-                    .buffer_unordered(num_threads as usize)
+                    .buffer_unordered(CONCURRENCY)
                     .collect::<Vec<_>>()
                     .await;
             },

--- a/benches/collection/read.rs
+++ b/benches/collection/read.rs
@@ -1,4 +1,10 @@
-use criterion::Criterion;
+use std::sync::Arc;
+
+use criterion::{BatchSize, Criterion};
+use futures::{
+    executor::block_on,
+    stream::{self, StreamExt},
+};
 
 use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
@@ -11,24 +17,30 @@ pub fn single_read(c: &mut Criterion) {
     let mut group = benchmark_group(c, "Single read benchmarks");
 
     let rt = create_runtime();
-    let tempdir = create_tempdir();
-    let channel_service = create_channel_service();
-
-    let collection = rt.block_on(async {
-        create_collection_with_points(&tempdir, channel_service, None, generate_points(1)).await
-    });
 
     group.bench_function("single_read", |b| {
-        b.to_async(&rt).iter(|| async {
-            collection
-                .read_points(
-                    Some(vec![smoldb::storage::segment::PointId::Id(0)]),
-                    None,
-                    true,
-                )
-                .await
-                .unwrap();
-        })
+        let setup = move || {
+            let tempdir = create_tempdir();
+            let channel_service = create_channel_service();
+            block_on(async {
+                create_collection_with_points(&tempdir, channel_service, None, generate_points(1))
+                    .await
+            })
+        };
+        b.to_async(&rt).iter_batched(
+            setup,
+            |collection| async move {
+                collection
+                    .read_points(
+                        Some(vec![smoldb::storage::segment::PointId::Id(0)]),
+                        None,
+                        true,
+                    )
+                    .await
+                    .unwrap();
+            },
+            BatchSize::PerIteration,
+        );
     });
 }
 
@@ -38,29 +50,44 @@ pub fn concurrent_read(c: &mut Criterion) {
     let mut group = benchmark_group(c, "Concurrent read benchmarks");
 
     let rt = create_runtime();
-    let tempdir = create_tempdir();
-
+    let rt_handle = rt.handle().clone();
     let num_points = 100_000;
     let num_threads = 4;
     let chunk_size = (num_points / num_threads) as usize;
 
-    let points = generate_points(num_points);
-    let point_ids = points.iter().map(|p| p.id.clone()).collect::<Vec<_>>();
-
-    let channel_service = create_channel_service();
-
-    let collection = rt.block_on(async {
-        create_collection_with_points(&tempdir, channel_service, None, points).await
-    });
-
     group.bench_function("concurrent_read", |b| {
-        b.to_async(&rt).iter(|| async {
-            for chunk in point_ids.chunks(chunk_size) {
-                collection
-                    .read_points(Some(chunk.to_vec()), None, true)
-                    .await
-                    .unwrap();
-            }
-        })
+        let rt_handle = rt_handle.clone();
+        let num_points = num_points;
+        let chunk_size = chunk_size;
+        let setup = move || {
+            let tempdir = create_tempdir();
+            let channel_service = create_channel_service();
+            let points = generate_points(num_points);
+            let point_ids = points.iter().map(|p| p.id.clone()).collect::<Vec<_>>();
+            let collection = block_on(async {
+                create_collection_with_points(&tempdir, channel_service, None, points).await
+            });
+            (Arc::new(collection), point_ids, chunk_size, num_threads)
+        };
+        b.to_async(&rt).iter_batched(
+            setup,
+            |(collection, point_ids, chunk_size, num_threads)| async move {
+                stream::iter(point_ids.chunks(chunk_size))
+                    .map(|chunk| {
+                        let collection_clone = collection.clone();
+                        let chunk = chunk.to_vec();
+                        async move {
+                            collection_clone
+                                .read_points(Some(chunk), None, true)
+                                .await
+                                .unwrap()
+                        }
+                    })
+                    .buffer_unordered(num_threads as usize)
+                    .collect::<Vec<_>>()
+                    .await;
+            },
+            BatchSize::PerIteration,
+        );
     });
 }

--- a/benches/collection/read.rs
+++ b/benches/collection/read.rs
@@ -11,14 +11,13 @@ use crate::common::{
     create_tempdir, generate_points,
 };
 
-// Perf in the beginning: ???
-// Perf with hashring and tokio: 729.73 ns
-pub fn single_read(c: &mut Criterion) {
-    let mut group = benchmark_group(c, "Single read benchmarks");
+pub fn read(c: &mut Criterion) {
+    let mut group = benchmark_group(c, "read");
 
-    let rt = create_runtime();
-
-    group.bench_function("single_read", |b| {
+    // Perf in the beginning: ???
+    // Perf with hashring and tokio: 729.73 ns
+    group.bench_function("single", |b| {
+        let rt = create_runtime();
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
@@ -42,23 +41,15 @@ pub fn single_read(c: &mut Criterion) {
             BatchSize::PerIteration,
         );
     });
-}
 
-// Perf in the beginning: ???
-// Perf with hashring and tokio: 124.54ms (100_000 points, 4 threads, 2 shards; only 170x slower than single read)
-pub fn concurrent_read(c: &mut Criterion) {
-    let mut group = benchmark_group(c, "Concurrent read benchmarks");
+    // Perf in the beginning: ???
+    // Perf with hashring and tokio: 124.54ms (100_000 points, 4 threads, 2 shards; only 170x slower than single read)
+    group.bench_function("concurrent", |b| {
+        let rt = create_runtime();
+        let num_points = 100_000;
+        let num_threads = 4;
+        let chunk_size = (num_points / num_threads) as usize;
 
-    let rt = create_runtime();
-    let rt_handle = rt.handle().clone();
-    let num_points = 100_000;
-    let num_threads = 4;
-    let chunk_size = (num_points / num_threads) as usize;
-
-    group.bench_function("concurrent_read", |b| {
-        let rt_handle = rt_handle.clone();
-        let num_points = num_points;
-        let chunk_size = chunk_size;
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();

--- a/benches/collection/read.rs
+++ b/benches/collection/read.rs
@@ -20,62 +20,51 @@ pub fn read(c: &mut Criterion) {
     // Read a single point when there are NUM_POINTS points in the collection
     group.bench_function("single", |b| {
         let rt = create_runtime();
-        let setup = move || {
-            let tempdir = create_tempdir();
-            let channel_service = create_channel_service();
-            block_on(async {
-                create_collection_with_points(
-                    &tempdir,
-                    channel_service,
-                    None,
-                    generate_points(NUM_POINTS), // insert many points but query only for the last one
-                )
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let collection = block_on(async {
+            create_collection_with_points(
+                &tempdir,
+                channel_service,
+                None,
+                generate_points(NUM_POINTS), // insert many points but query only for the last one
+            )
+            .await
+        });
+        b.to_async(&rt).iter(|| async {
+            collection
+                .read_points(Some(vec![PointId::Id(NUM_POINTS - 1)]), None, true)
                 .await
-            })
-        };
-        b.to_async(&rt).iter_batched(
-            setup,
-            |collection| async move {
-                collection
-                    .read_points(Some(vec![PointId::Id(NUM_POINTS - 1)]), None, true)
-                    .await
-                    .unwrap();
-            },
-            BatchSize::PerIteration,
-        );
+                .unwrap();
+        });
     });
 
     // Read 1 batch of BATCH_SIZE points while there are NUM_POINTS points in the collection
     group.throughput(Throughput::Elements(BATCH_SIZE as u64));
     group.bench_function("batch", |b| {
         let rt = create_runtime();
-        let setup = move || {
-            let tempdir = create_tempdir();
-            let channel_service = create_channel_service();
-            let collection = block_on(async {
-                create_collection_with_points(
-                    &tempdir,
-                    channel_service,
-                    None,
-                    generate_points(NUM_POINTS),
-                )
+
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let collection = block_on(async {
+            create_collection_with_points(
+                &tempdir,
+                channel_service,
+                None,
+                generate_points(NUM_POINTS),
+            )
+            .await
+        });
+        let read_batch = (0..BATCH_SIZE)
+            .map(|i| PointId::Id(i as u64))
+            .collect::<Vec<_>>();
+
+        b.to_async(&rt).iter(|| async {
+            collection
+                .read_points(Some(read_batch), None, true)
                 .await
-            });
-            let read_batch = (0..BATCH_SIZE)
-                .map(|i| PointId::Id(i as u64))
-                .collect::<Vec<_>>();
-            (collection, read_batch)
-        };
-        b.to_async(&rt).iter_batched(
-            setup,
-            |(collection, read_batch)| async move {
-                collection
-                    .read_points(Some(read_batch), None, true)
-                    .await
-                    .unwrap();
-            },
-            BatchSize::PerIteration,
-        );
+                .unwrap();
+        });
     });
 
     // Perf in the beginning: ???
@@ -85,35 +74,29 @@ pub fn read(c: &mut Criterion) {
     group.bench_function("concurrent", |b| {
         let rt = create_runtime();
 
-        let setup = move || {
-            let tempdir = create_tempdir();
-            let channel_service = create_channel_service();
-            let points = generate_points(NUM_POINTS);
-            let all_point_ids = points.iter().map(|p| p.id.clone()).collect::<Vec<_>>();
-            let collection = block_on(async {
-                create_collection_with_points(&tempdir, channel_service, None, points).await
-            });
-            (Arc::new(collection), all_point_ids)
-        };
-        b.to_async(&rt).iter_batched(
-            setup,
-            |(collection, all_point_ids)| async move {
-                stream::iter(all_point_ids.chunks(BATCH_SIZE))
-                    .map(|chunk| {
-                        let collection_clone = collection.clone();
-                        let chunk = chunk.to_vec();
-                        async move {
-                            collection_clone
-                                .read_points(Some(chunk), None, true)
-                                .await
-                                .unwrap()
-                        }
-                    })
-                    .buffer_unordered(CONCURRENCY)
-                    .collect::<Vec<_>>()
-                    .await;
-            },
-            BatchSize::PerIteration,
-        );
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let points = generate_points(NUM_POINTS);
+        let all_point_ids = points.iter().map(|p| p.id.clone()).collect::<Vec<_>>();
+        let collection = block_on(async {
+            create_collection_with_points(&tempdir, channel_service, None, points).await
+        });
+        let collection_arc = Arc::new(collection);
+        b.to_async(&rt).iter(|| async {
+            stream::iter(all_point_ids.chunks(BATCH_SIZE))
+                .map(|chunk| {
+                    let collection_clone = collection_arc.clone();
+                    let chunk = chunk.to_vec();
+                    async move {
+                        collection_clone
+                            .read_points(Some(chunk), None, true)
+                            .await
+                            .unwrap()
+                    }
+                })
+                .buffer_unordered(CONCURRENCY)
+                .collect::<Vec<_>>()
+                .await;
+        });
     });
 }

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -20,28 +20,20 @@ use smoldb::{
 };
 
 // Perf when bench was first implemented: single=1.5804 µs, concurrent=5.7696 µs
-pub fn text_query_benchmarks(c: &mut Criterion) {
-    let mut group = benchmark_group(c, "Text query benchmarks");
-
-    let rt = create_runtime();
-    let rt_handle = rt.handle().clone();
-    let num_points = 100_000;
-    let num_threads = 4;
-    let chunk_size = (num_points / num_threads) as usize;
+pub fn text_query(c: &mut Criterion) {
+    let mut group = benchmark_group(c, "query/text");
 
     // Single text query benchmark
-    let single_query = Query {
-        filter: QueryFilter::new("text", Value::from("100"), FilterOperator::Eq),
-        limit: Some(10),
-    };
-
-    group.bench_function("single_text_query", |b| {
-        let num_points = num_points;
-        let query = single_query.clone();
+    group.bench_function("single", |b| {
+        let query = Query {
+            filter: QueryFilter::new("text", Value::from("100"), FilterOperator::Eq),
+            limit: Some(10),
+        };
+        let rt = create_runtime();
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
-            let points = generate_points(num_points);
+            let points = generate_points(1);
             let collection = block_on(async {
                 let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
                 create_collection_with_points(
@@ -67,24 +59,26 @@ pub fn text_query_benchmarks(c: &mut Criterion) {
     });
 
     // Concurrent text query benchmark
-    let queries: Vec<Query> = (0..num_threads)
-        .map(|i| {
-            let start_id = i * chunk_size as u64;
-            Query {
-                filter: QueryFilter::new(
-                    "text",
-                    Value::from(format!("{start_id}")),
-                    FilterOperator::Gte,
-                ),
-                limit: Some(10),
-            }
-        })
-        .collect();
+    group.bench_function("concurrent", |b| {
+        let rt = create_runtime();
+        let num_points = 100_000;
+        let num_threads = 4;
+        let chunk_size = (num_points / num_threads) as usize;
 
-    group.bench_function("concurrent_text_query", |b| {
-        let rt_handle = rt_handle.clone();
-        let num_points = num_points;
-        let queries = queries.clone();
+        let queries: Vec<Query> = (0..num_threads)
+            .map(|i| {
+                let start_id = i * chunk_size as u64;
+                Query {
+                    filter: QueryFilter::new(
+                        "text",
+                        Value::from(format!("{start_id}")),
+                        FilterOperator::Gte,
+                    ),
+                    limit: Some(10),
+                }
+            })
+            .collect();
+
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -18,29 +18,22 @@ pub fn text_query(c: &mut Criterion) {
     // Single text query benchmark
     group.bench_function("single", |b| {
         let rt = create_runtime();
-        let setup = move || {
-            let query = generate_text_queries(1).first().unwrap().clone();
-            let tempdir = create_tempdir();
-            let channel_service = create_channel_service();
-            let collection = block_on(async {
-                let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
-                create_collection_with_points(
-                    &tempdir,
-                    channel_service,
-                    Some(payload_index),
-                    generate_points(NUM_POINTS),
-                )
-                .await
-            });
-            (Arc::new(collection), query)
-        };
-        b.to_async(&rt).iter_batched(
-            setup,
-            move |(collection_arc, query)| async move {
-                collection_arc.query_points(query, true).await.unwrap();
-            },
-            BatchSize::PerIteration,
-        );
+        let query = generate_text_queries(1).first().unwrap().clone();
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let collection = block_on(async {
+            let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
+            create_collection_with_points(
+                &tempdir,
+                channel_service,
+                Some(payload_index),
+                generate_points(NUM_POINTS),
+            )
+            .await
+        });
+        b.to_async(&rt).iter(|| async {
+            collection.query_points(query.clone(), true).await.unwrap();
+        });
     });
 
     // todo: Query a single batch of RW_BATCH_SIZE points while there are NUM_POINTS points in the collection
@@ -52,35 +45,29 @@ pub fn text_query(c: &mut Criterion) {
     // So we can just run NUM_QUERIES queries in CONCURRENCY parallel with batch size=1
     group.bench_function("concurrent", |b| {
         let rt = create_runtime();
-        let setup = move || {
-            let queries = generate_text_queries(NUM_QUERIES);
-            let tempdir = create_tempdir();
-            let channel_service = create_channel_service();
-            let collection = block_on(async {
-                let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
-                create_collection_with_points(
-                    &tempdir,
-                    channel_service,
-                    Some(payload_index),
-                    generate_points(NUM_POINTS),
-                )
-                .await
-            });
-            (Arc::new(collection), queries)
-        };
-        b.to_async(&rt).iter_batched(
-            setup,
-            move |(collection_arc, queries)| async move {
-                stream::iter(queries)
-                    .map(|query| {
-                        let collection_clone = collection_arc.clone();
-                        async move { collection_clone.query_points(query, true).await.unwrap() }
-                    })
-                    .buffer_unordered(CONCURRENCY)
-                    .collect::<Vec<_>>()
-                    .await;
-            },
-            BatchSize::PerIteration,
-        );
+        let queries = generate_text_queries(NUM_QUERIES);
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let collection = block_on(async {
+            let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
+            create_collection_with_points(
+                &tempdir,
+                channel_service,
+                Some(payload_index),
+                generate_points(NUM_POINTS),
+            )
+            .await
+        });
+        let collection_arc = Arc::new(collection);
+        b.to_async(&rt).iter(|| async {
+            stream::iter(queries)
+                .map(|query| {
+                    let collection_clone = collection_arc.clone();
+                    async move { collection_clone.query_points(query, true).await.unwrap() }
+                })
+                .buffer_unordered(CONCURRENCY)
+                .collect::<Vec<_>>()
+                .await;
+        });
     });
 }

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -1,23 +1,15 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use criterion::{BatchSize, Criterion};
+use crate::common::{
+    benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
+    create_tempdir, generate_points, generate_text_queries, CONCURRENCY, NUM_POINTS, NUM_QUERIES,
+};
+use criterion::{BatchSize, Criterion, Throughput};
 use futures::{
     executor::block_on,
     stream::{self, StreamExt},
 };
-use serde_json::Value;
-
-use crate::common::{
-    benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
-    create_tempdir, generate_points,
-};
-use smoldb::{
-    api::points::Query,
-    storage::index::{
-        filter::{FilterOperator, QueryFilter},
-        payload_index::IndexConfig,
-    },
-};
+use smoldb::storage::index::payload_index::IndexConfig;
 
 // Perf when bench was first implemented: single=1.5804 µs, concurrent=5.7696 µs
 pub fn text_query(c: &mut Criterion) {
@@ -25,85 +17,66 @@ pub fn text_query(c: &mut Criterion) {
 
     // Single text query benchmark
     group.bench_function("single", |b| {
-        let query = Query {
-            filter: QueryFilter::new("text", Value::from("100"), FilterOperator::Eq),
-            limit: Some(10),
-        };
         let rt = create_runtime();
         let setup = move || {
+            let query = generate_text_queries(1).first().unwrap().clone();
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
-            let points = generate_points(1);
             let collection = block_on(async {
                 let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
                 create_collection_with_points(
                     &tempdir,
                     channel_service,
                     Some(payload_index),
-                    points,
+                    generate_points(NUM_POINTS),
                 )
                 .await
             });
-            Arc::new(collection)
+            (Arc::new(collection), query)
         };
         b.to_async(&rt).iter_batched(
             setup,
-            move |collection_arc| {
-                let query = query.clone();
-                async move {
-                    collection_arc.query_points(query, true).await.unwrap();
-                }
+            move |(collection_arc, query)| async move {
+                collection_arc.query_points(query, true).await.unwrap();
             },
             BatchSize::PerIteration,
         );
     });
 
-    // Concurrent text query benchmark
+    // todo: Query a single batch of RW_BATCH_SIZE points while there are NUM_POINTS points in the collection
+    // It needs support from the API to pass a batch of queries
+
+    group.throughput(Throughput::Elements(NUM_QUERIES as u64));
+
+    // For querying, batch size is always 1 (for now)
+    // So we can just run NUM_QUERIES queries in CONCURRENCY parallel with batch size=1
     group.bench_function("concurrent", |b| {
         let rt = create_runtime();
-        let num_points = 100_000;
-        let num_threads = 4;
-        let chunk_size = (num_points / num_threads) as usize;
-
-        let queries: Vec<Query> = (0..num_threads)
-            .map(|i| {
-                let start_id = i * chunk_size as u64;
-                Query {
-                    filter: QueryFilter::new(
-                        "text",
-                        Value::from(format!("{start_id}")),
-                        FilterOperator::Gte,
-                    ),
-                    limit: Some(10),
-                }
-            })
-            .collect();
-
         let setup = move || {
+            let queries = generate_text_queries(NUM_QUERIES);
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
-            let points = generate_points(num_points);
             let collection = block_on(async {
                 let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
                 create_collection_with_points(
                     &tempdir,
                     channel_service,
                     Some(payload_index),
-                    points,
+                    generate_points(NUM_POINTS),
                 )
                 .await
             });
-            (Arc::new(collection), queries.clone(), num_threads)
+            (Arc::new(collection), queries)
         };
         b.to_async(&rt).iter_batched(
             setup,
-            move |(collection_arc, queries, num_threads)| async move {
+            move |(collection_arc, queries)| async move {
                 stream::iter(queries)
                     .map(|query| {
                         let collection_clone = collection_arc.clone();
                         async move { collection_clone.query_points(query, true).await.unwrap() }
                     })
-                    .buffer_unordered(num_threads as usize)
+                    .buffer_unordered(CONCURRENCY)
                     .collect::<Vec<_>>()
                     .await;
             },

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -4,7 +4,7 @@ use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
     create_tempdir, generate_points, generate_text_queries, CONCURRENCY, NUM_POINTS, NUM_QUERIES,
 };
-use criterion::{BatchSize, Criterion, Throughput};
+use criterion::{Criterion, Throughput};
 use futures::{
     executor::block_on,
     stream::{self, StreamExt},
@@ -60,7 +60,7 @@ pub fn text_query(c: &mut Criterion) {
         });
         let collection_arc = Arc::new(collection);
         b.to_async(&rt).iter(|| async {
-            stream::iter(queries)
+            stream::iter(queries.clone())
                 .map(|query| {
                     let collection_clone = collection_arc.clone();
                     async move { collection_clone.query_points(query, true).await.unwrap() }

--- a/benches/collection/text_search.rs
+++ b/benches/collection/text_search.rs
@@ -1,6 +1,10 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use criterion::Criterion;
+use criterion::{BatchSize, Criterion};
+use futures::{
+    executor::block_on,
+    stream::{self, StreamExt},
+};
 use serde_json::Value;
 
 use crate::common::{
@@ -15,64 +19,54 @@ use smoldb::{
     },
 };
 
-// Perf when bench was first implemented: 1.5804 µs
-pub fn single_text_query(c: &mut Criterion) {
-    let mut group = benchmark_group(c, "Single text query benchmarks");
+// Perf when bench was first implemented: single=1.5804 µs, concurrent=5.7696 µs
+pub fn text_query_benchmarks(c: &mut Criterion) {
+    let mut group = benchmark_group(c, "Text query benchmarks");
 
     let rt = create_runtime();
-    let tempdir = create_tempdir();
-    let channel_service = create_channel_service();
+    let rt_handle = rt.handle().clone();
     let num_points = 100_000;
+    let num_threads = 4;
+    let chunk_size = (num_points / num_threads) as usize;
 
-    let collection = rt.block_on(async {
-        let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
-        create_collection_with_points(
-            &tempdir,
-            channel_service,
-            Some(payload_index),
-            generate_points(num_points),
-        )
-        .await
-    });
-    let collection_arc = Arc::new(collection);
-
-    let query = Query {
+    // Single text query benchmark
+    let single_query = Query {
         filter: QueryFilter::new("text", Value::from("100"), FilterOperator::Eq),
         limit: Some(10),
     };
 
     group.bench_function("single_text_query", |b| {
-        b.to_async(&rt).iter(|| async {
-            collection_arc
-                .query_points(query.clone(), true)
+        let num_points = num_points;
+        let query = single_query.clone();
+        let setup = move || {
+            let tempdir = create_tempdir();
+            let channel_service = create_channel_service();
+            let points = generate_points(num_points);
+            let collection = block_on(async {
+                let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
+                create_collection_with_points(
+                    &tempdir,
+                    channel_service,
+                    Some(payload_index),
+                    points,
+                )
                 .await
-                .unwrap();
-        })
+            });
+            Arc::new(collection)
+        };
+        b.to_async(&rt).iter_batched(
+            setup,
+            move |collection_arc| {
+                let query = query.clone();
+                async move {
+                    collection_arc.query_points(query, true).await.unwrap();
+                }
+            },
+            BatchSize::PerIteration,
+        );
     });
-}
 
-// Perf when bench was first implemented: 5.7696 µs
-pub fn concurrent_text_query(c: &mut Criterion) {
-    let mut group = benchmark_group(c, "Concurrent text query benchmarks");
-
-    let rt = create_runtime();
-    let tempdir = create_tempdir();
-
-    let num_points = 100_000;
-    let num_threads = 4;
-    let chunk_size = (num_points / num_threads) as usize;
-
-    let points = generate_points(num_points);
-
-    let channel_service = create_channel_service();
-
-    let collection = rt.block_on(async {
-        let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
-        create_collection_with_points(&tempdir, channel_service, Some(payload_index), points).await
-    });
-    let collection_arc = Arc::new(collection);
-
-    // Create queries for different chunks - filtering on different message values
+    // Concurrent text query benchmark
     let queries: Vec<Query> = (0..num_threads)
         .map(|i| {
             let start_id = i * chunk_size as u64;
@@ -88,13 +82,38 @@ pub fn concurrent_text_query(c: &mut Criterion) {
         .collect();
 
     group.bench_function("concurrent_text_query", |b| {
-        b.to_async(&rt).iter(|| async {
-            for query in &queries {
-                collection_arc
-                    .query_points(query.clone(), true)
-                    .await
-                    .unwrap();
-            }
-        })
+        let rt_handle = rt_handle.clone();
+        let num_points = num_points;
+        let queries = queries.clone();
+        let setup = move || {
+            let tempdir = create_tempdir();
+            let channel_service = create_channel_service();
+            let points = generate_points(num_points);
+            let collection = block_on(async {
+                let payload_index = BTreeMap::from_iter([("text".to_string(), IndexConfig::Text)]);
+                create_collection_with_points(
+                    &tempdir,
+                    channel_service,
+                    Some(payload_index),
+                    points,
+                )
+                .await
+            });
+            (Arc::new(collection), queries.clone(), num_threads)
+        };
+        b.to_async(&rt).iter_batched(
+            setup,
+            move |(collection_arc, queries, num_threads)| async move {
+                stream::iter(queries)
+                    .map(|query| {
+                        let collection_clone = collection_arc.clone();
+                        async move { collection_clone.query_points(query, true).await.unwrap() }
+                    })
+                    .buffer_unordered(num_threads as usize)
+                    .collect::<Vec<_>>()
+                    .await;
+            },
+            BatchSize::PerIteration,
+        );
     });
 }

--- a/benches/collection/write.rs
+++ b/benches/collection/write.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use criterion::{BatchSize, Criterion, Throughput};
+use criterion::{Criterion, Throughput};
 use futures::{
     executor::block_on,
     stream::{self, StreamExt},
@@ -16,88 +16,70 @@ pub fn write(c: &mut Criterion) {
 
     // Takes 619.19 ns on my machine
     // After hashring and tokio: 874.32 ns
-    // Write a single point in an **empty** collection
+    // Write a single point in a collection with 0-1 points
     group.bench_function("single", |b| {
         let rt = create_runtime();
-        let setup = move || {
-            let tempdir = create_tempdir();
-            let channel_service = create_channel_service();
-            let collection = block_on(async {
-                create_collection("test_collection", &tempdir, channel_service, None).await
-            });
-            let single_point_batch = generate_points(1);
-            (collection, single_point_batch)
-        };
-        b.to_async(&rt).iter_batched(
-            setup,
-            move |(collection, single_point_batch)| async move {
-                collection
-                    .upsert_points(single_point_batch.to_vec(), true)
-                    .await
-                    .unwrap();
-            },
-            BatchSize::PerIteration,
-        );
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let collection = block_on(async {
+            create_collection("test_collection", &tempdir, channel_service, None).await
+        });
+        let single_point_batch = generate_points(1);
+        b.to_async(&rt).iter(|| async {
+            collection
+                .upsert_points(single_point_batch.to_vec(), true)
+                .await
+                .unwrap();
+        })
     });
 
     group.throughput(Throughput::Elements(BATCH_SIZE as u64));
 
-    // Write a single batch of BATCH_SIZE points in an **empty** collection
+    // Write a single sequential batch of BATCH_SIZE points in an **empty** collection
     group.bench_function("batch", |b| {
         let rt = create_runtime();
-        let setup = move || {
-            let tempdir = create_tempdir();
-            let channel_service = create_channel_service();
-            let collection = block_on(async {
-                create_collection("test_collection", &tempdir, channel_service, None).await
-            });
-            let write_batch = generate_points(BATCH_SIZE as u64).to_vec();
-            (collection, write_batch)
-        };
-        b.to_async(&rt).iter_batched(
-            setup,
-            |(collection, write_batch)| async move {
-                collection.upsert_points(write_batch, true).await.unwrap();
-            },
-            BatchSize::PerIteration,
-        );
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let collection = block_on(async {
+            create_collection("test_collection", &tempdir, channel_service, None).await
+        });
+        let write_batch = generate_points(BATCH_SIZE as u64);
+        b.to_async(&rt).iter(|| async {
+            collection
+                .upsert_points(write_batch.to_vec(), true)
+                .await
+                .unwrap();
+        });
     });
 
     group.throughput(Throughput::Elements(NUM_POINTS));
 
-    // Write NUM_POINTS points in CONCURRENCY parallel batches of BATCH_SIZE points in an **empty** collection
+    // Write sequential NUM_POINTS points in CONCURRENCY parallel batches of BATCH_SIZE points in an **empty** collection
     // Takes 68.347 ms on my machine
     // After hashring and tokio: 172.99ms
     group.bench_function("concurrent", |b| {
         let rt = create_runtime();
-        let setup = move || {
-            let tempdir = create_tempdir();
-            let channel_service = create_channel_service();
-            let collection = block_on(async {
-                create_collection("test_collection", &tempdir, channel_service, None).await
-            });
-            let collection_arc = Arc::new(collection);
-            let all_points = generate_points(NUM_POINTS);
-            (collection_arc, all_points)
-        };
-        b.to_async(&rt).iter_batched(
-            setup,
-            |(collection_arc, all_points)| async move {
-                stream::iter(all_points.chunks(BATCH_SIZE))
-                    .map(|write_batch| {
-                        let collection_clone = collection_arc.clone();
-                        async move {
-                            collection_clone
-                                .upsert_points(write_batch.to_vec(), true)
-                                .await
-                                .unwrap()
-                        }
-                    })
-                    .buffer_unordered(CONCURRENCY)
-                    .collect::<Vec<_>>()
-                    .await;
-            },
-            BatchSize::PerIteration,
-        );
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let collection = block_on(async {
+            create_collection("test_collection", &tempdir, channel_service, None).await
+        });
+        let collection_arc = Arc::new(collection);
+        let all_points = generate_points(NUM_POINTS);
+        b.to_async(&rt).iter(|| async {
+            stream::iter(all_points.chunks(BATCH_SIZE))
+                .map(|write_batch| {
+                    let collection_clone = collection_arc.clone();
+                    async move {
+                        collection_clone
+                            .upsert_points(write_batch.to_vec(), true)
+                            .await
+                            .unwrap()
+                    }
+                })
+                .buffer_unordered(CONCURRENCY)
+                .collect::<Vec<_>>()
+                .await;
+        });
     });
 }

--- a/benches/collection/write.rs
+++ b/benches/collection/write.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use criterion::{BatchSize, Criterion};
+use criterion::{BatchSize, Criterion, Throughput};
 use futures::{
     executor::block_on,
     stream::{self, StreamExt},
@@ -8,7 +8,7 @@ use futures::{
 
 use crate::common::{
     benchmark_group, create_channel_service, create_collection, create_runtime, create_tempdir,
-    generate_points,
+    generate_points, BATCH_SIZE, CONCURRENCY, NUM_POINTS,
 };
 
 pub fn write(c: &mut Criterion) {
@@ -16,39 +16,60 @@ pub fn write(c: &mut Criterion) {
 
     // Takes 619.19 ns on my machine
     // After hashring and tokio: 874.32 ns
+    // Write a single point in an **empty** collection
     group.bench_function("single", |b| {
         let rt = create_runtime();
-        let points = generate_points(1);
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
-            block_on(async {
+            let collection = block_on(async {
                 create_collection("test_collection", &tempdir, channel_service, None).await
-            })
+            });
+            let single_point_batch = generate_points(1);
+            (collection, single_point_batch)
         };
         b.to_async(&rt).iter_batched(
             setup,
-            move |collection| {
-                let points = points.clone();
-                async move {
-                    collection
-                        .upsert_points(points.to_vec(), true)
-                        .await
-                        .unwrap();
-                }
+            move |(collection, single_point_batch)| async move {
+                collection
+                    .upsert_points(single_point_batch.to_vec(), true)
+                    .await
+                    .unwrap();
             },
             BatchSize::PerIteration,
         );
     });
 
+    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+
+    // Write a single batch of BATCH_SIZE points in an **empty** collection
+    group.bench_function("batch", |b| {
+        let rt = create_runtime();
+        let setup = move || {
+            let tempdir = create_tempdir();
+            let channel_service = create_channel_service();
+            let collection = block_on(async {
+                create_collection("test_collection", &tempdir, channel_service, None).await
+            });
+            let write_batch = generate_points(BATCH_SIZE as u64).to_vec();
+            (collection, write_batch)
+        };
+        b.to_async(&rt).iter_batched(
+            setup,
+            |(collection, write_batch)| async move {
+                collection.upsert_points(write_batch, true).await.unwrap();
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.throughput(Throughput::Elements(NUM_POINTS as u64));
+
+    // Write NUM_POINTS points in CONCURRENCY parallel batches of BATCH_SIZE points in an **empty** collection
     // Takes 68.347 ms on my machine
     // After hashring and tokio: 172.99ms
     group.bench_function("concurrent", |b| {
         let rt = create_runtime();
-        let num_points = 100_000;
-        let num_threads = 16;
-        let chunk_size = (num_points / num_threads) as usize;
-
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
@@ -56,19 +77,23 @@ pub fn write(c: &mut Criterion) {
                 create_collection("test_collection", &tempdir, channel_service, None).await
             });
             let collection_arc = Arc::new(collection);
-            let points = generate_points(num_points);
-            (collection_arc, points, chunk_size, num_threads)
+            let all_points = generate_points(NUM_POINTS);
+            (collection_arc, all_points)
         };
         b.to_async(&rt).iter_batched(
             setup,
-            |(collection_arc, points, chunk_size, num_threads)| async move {
-                stream::iter(points.chunks(chunk_size))
-                    .map(|chunk| {
+            |(collection_arc, all_points)| async move {
+                stream::iter(all_points.chunks(BATCH_SIZE))
+                    .map(|write_batch| {
                         let collection_clone = collection_arc.clone();
-                        let chunk = chunk.to_vec();
-                        async move { collection_clone.upsert_points(chunk, true).await.unwrap() }
+                        async move {
+                            collection_clone
+                                .upsert_points(write_batch.to_vec(), true)
+                                .await
+                                .unwrap()
+                        }
                     })
-                    .buffer_unordered(num_threads as usize)
+                    .buffer_unordered(CONCURRENCY)
                     .collect::<Vec<_>>()
                     .await;
             },

--- a/benches/collection/write.rs
+++ b/benches/collection/write.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use criterion::Criterion;
+use criterion::{BatchSize, Criterion};
+use futures::{
+    executor::block_on,
+    stream::{self, StreamExt},
+};
 
 use crate::common::{
     benchmark_group, create_channel_service, create_collection, create_runtime, create_tempdir,
@@ -13,22 +17,30 @@ pub fn single_write(c: &mut Criterion) {
     let mut group = benchmark_group(c, "Single write benchmarks");
 
     let rt = create_runtime();
-    let tempdir = create_tempdir();
-    let channel_service = create_channel_service();
-
-    let collection = rt.block_on(async {
-        create_collection("test_collection", &tempdir, channel_service.clone(), None).await
-    });
-
     let points = generate_points(1);
 
     group.bench_function("single_write", |b| {
-        b.to_async(&rt).iter(|| async {
-            collection
-                .upsert_points(points.to_vec(), true)
-                .await
-                .unwrap();
-        })
+        let points = points.clone();
+        let setup = move || {
+            let tempdir = create_tempdir();
+            let channel_service = create_channel_service();
+            block_on(async {
+                create_collection("test_collection", &tempdir, channel_service, None).await
+            })
+        };
+        b.to_async(&rt).iter_batched(
+            setup,
+            move |collection| {
+                let points = points.clone();
+                async move {
+                    collection
+                        .upsert_points(points.to_vec(), true)
+                        .await
+                        .unwrap();
+                }
+            },
+            BatchSize::PerIteration,
+        );
     });
 }
 
@@ -38,29 +50,39 @@ pub fn concurrent_write(c: &mut Criterion) {
     let mut group = benchmark_group(c, "Concurrent write benchmarks");
 
     let rt = create_runtime();
-    let tempdir = create_tempdir();
-    let channel_service = create_channel_service();
-
-    let collection = rt.block_on(async {
-        create_collection("test_collection", &tempdir, channel_service, None).await
-    });
-    let collection_arc = Arc::new(collection);
-
+    let rt_handle = rt.handle().clone();
     let num_points = 100_000;
     let num_threads = 16;
     let chunk_size = (num_points / num_threads) as usize;
 
-    let points = generate_points(num_points);
-
     group.bench_function("concurrent_write", |b| {
-        b.to_async(&rt).iter(|| async {
-            for chunk in points.chunks(chunk_size) {
-                let collection_clone = collection_arc.clone();
-                collection_clone
-                    .upsert_points(chunk.to_vec(), true)
-                    .await
-                    .unwrap();
-            }
-        })
+        let rt_handle = rt_handle.clone();
+        let num_points = num_points;
+        let chunk_size = chunk_size;
+        let setup = move || {
+            let tempdir = create_tempdir();
+            let channel_service = create_channel_service();
+            let collection = block_on(async {
+                create_collection("test_collection", &tempdir, channel_service, None).await
+            });
+            let collection_arc = Arc::new(collection);
+            let points = generate_points(num_points);
+            (collection_arc, points, chunk_size, num_threads)
+        };
+        b.to_async(&rt).iter_batched(
+            setup,
+            |(collection_arc, points, chunk_size, num_threads)| async move {
+                stream::iter(points.chunks(chunk_size))
+                    .map(|chunk| {
+                        let collection_clone = collection_arc.clone();
+                        let chunk = chunk.to_vec();
+                        async move { collection_clone.upsert_points(chunk, true).await.unwrap() }
+                    })
+                    .buffer_unordered(num_threads as usize)
+                    .collect::<Vec<_>>()
+                    .await;
+            },
+            BatchSize::PerIteration,
+        );
     });
 }

--- a/benches/collection/write.rs
+++ b/benches/collection/write.rs
@@ -63,7 +63,7 @@ pub fn write(c: &mut Criterion) {
         );
     });
 
-    group.throughput(Throughput::Elements(NUM_POINTS as u64));
+    group.throughput(Throughput::Elements(NUM_POINTS));
 
     // Write NUM_POINTS points in CONCURRENCY parallel batches of BATCH_SIZE points in an **empty** collection
     // Takes 68.347 ms on my machine

--- a/benches/collection/write.rs
+++ b/benches/collection/write.rs
@@ -11,16 +11,14 @@ use crate::common::{
     generate_points,
 };
 
-// Takes 619.19 ns on my machine
-// After hashring and tokio: 874.32 ns
-pub fn single_write(c: &mut Criterion) {
-    let mut group = benchmark_group(c, "Single write benchmarks");
+pub fn write(c: &mut Criterion) {
+    let mut group = benchmark_group(c, "write");
 
-    let rt = create_runtime();
-    let points = generate_points(1);
-
-    group.bench_function("single_write", |b| {
-        let points = points.clone();
+    // Takes 619.19 ns on my machine
+    // After hashring and tokio: 874.32 ns
+    group.bench_function("single", |b| {
+        let rt = create_runtime();
+        let points = generate_points(1);
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();
@@ -42,23 +40,15 @@ pub fn single_write(c: &mut Criterion) {
             BatchSize::PerIteration,
         );
     });
-}
 
-// Takes 68.347 ms on my machine
-// After hashring and tokio: 172.99ms
-pub fn concurrent_write(c: &mut Criterion) {
-    let mut group = benchmark_group(c, "Concurrent write benchmarks");
+    // Takes 68.347 ms on my machine
+    // After hashring and tokio: 172.99ms
+    group.bench_function("concurrent", |b| {
+        let rt = create_runtime();
+        let num_points = 100_000;
+        let num_threads = 16;
+        let chunk_size = (num_points / num_threads) as usize;
 
-    let rt = create_runtime();
-    let rt_handle = rt.handle().clone();
-    let num_points = 100_000;
-    let num_threads = 16;
-    let chunk_size = (num_points / num_threads) as usize;
-
-    group.bench_function("concurrent_write", |b| {
-        let rt_handle = rt_handle.clone();
-        let num_points = num_points;
-        let chunk_size = chunk_size;
         let setup = move || {
             let tempdir = create_tempdir();
             let channel_service = create_channel_service();


### PR DESCRIPTION
Group benchmarks and use futures to make the concurrent benchmarks actually concurrent, previously they were just batched.