### PR TITLE
Use rayon to parallize and speed up indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,6 +2930,7 @@ dependencies = [
  "protobuf",
  "raft",
  "rand 0.9.2",
+ "rayon",
  "rusty-hook",
  "serde",
  "serde_cbor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ utoipa-swagger-ui = {version = "9.0.2", features = ["actix-web"]}
 
 # storage layer:
 hashring = "0.3.6"
+rayon = "1.10"
 sled = { version = "0.34.7", default-features = false }
 
 # cli, logging, runtime, and other utilities:

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -6,6 +6,7 @@ use crate::{
         segment::{Point, PointId},
     },
 };
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sled::Db;
@@ -213,7 +214,11 @@ impl PayloadIndex {
     }
 
     pub fn insert_batch(&self, points: &[Point]) -> StorageResult<()> {
-        for (index_key, index_tree) in &self.indices {
+        // Only parallelize across indices when there are enough to overcome rayon overhead
+        // With 1-2 indices, sequential is faster due to thread spawn overhead
+        const MIN_INDICES_FOR_PARALLEL: usize = 3;
+
+        let index_fn = |(index_key, index_tree): (&String, &FieldIndex)| {
             // Collect both point_ids and values together, only for points that have the index key
             let mut point_ids = Vec::new();
             let mut index_values = Vec::new();
@@ -231,9 +236,15 @@ impl PayloadIndex {
             if !point_ids.is_empty() {
                 index_tree.add_points(&point_ids, &index_values)?;
             }
-        }
 
-        Ok(())
+            Ok(())
+        };
+
+        if self.indices.len() >= MIN_INDICES_FOR_PARALLEL {
+            self.indices.par_iter().try_for_each(index_fn)
+        } else {
+            self.indices.iter().try_for_each(index_fn)
+        }
     }
 
     // Todo: Support deleting points from the index in case of update or deletes

--- a/src/storage/segment/index/text/mod.rs
+++ b/src/storage/segment/index/text/mod.rs
@@ -5,6 +5,7 @@ mod tokenizer;
 use std::{cmp::Ordering, collections::BinaryHeap, sync::RwLock};
 
 use ahash::HashMap;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde_json::Value;
 use sled::Db;
 
@@ -185,17 +186,22 @@ impl FieldIndexTrait<&str> for TextIndex {
             })
             .collect::<Result<Vec<&str>, StorageError>>()?;
 
+        // Parallel tokenization: each document is tokenized independently
+        let tokenized: Vec<_> = texts
+            .par_iter()
+            .map(|text| tokenize_and_count_frequencies(text))
+            .collect();
+
         // Build temporary index in memory to batch all postings list updates
         let mut temp_index: HashMap<String, Vec<PostingListItem>> = HashMap::default();
         // Track document lengths for incremental BM25 stats updates
         let mut new_doc_lengths: HashMap<u64, u64> = HashMap::default();
 
-        for (point_id, text) in point_ids.iter().zip(texts.iter()) {
-            let terms = tokenize_and_count_frequencies(text);
-            let doc_length: u64 = terms.values().sum();
+        for (point_id, text_tokens) in point_ids.iter().zip(tokenized.into_iter()) {
+            let doc_length: u64 = text_tokens.values().sum();
             new_doc_lengths.insert(*point_id, doc_length);
 
-            for (term, term_freq) in terms {
+            for (term, term_freq) in text_tokens {
                 temp_index
                     .entry(term)
                     .or_default()

--- a/src/storage/segment/mod.rs
+++ b/src/storage/segment/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     storage::index::payload_index::{IndexConfig, PayloadIndex},
 };
 use futures::StreamExt;
+use rayon::prelude::*;
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
@@ -82,18 +83,45 @@ impl Segment {
 
     /// Insert a batch of points into the segment
     pub fn insert_points(&self, points: &[Point]) -> StorageResult<()> {
-        for point in points {
-            let key = point.id.encode()?;
-            let value = point.encode_payload()?;
-            self.db.insert(key, value).map_err(|e| {
-                StorageError::ServiceError(format!("Failed to insert point into segment db: {e}"))
-            })?;
+        // Only parallelize encoding for larger batches where rayon overhead is worthwhile
+        // CBOR encoding is ~200-500ns per point, rayon overhead is ~100-500ns per task
+        const PARALLEL_THRESHOLD: usize = 500;
+
+        let mut point_ids = Vec::with_capacity(points.len());
+
+        if points.len() >= PARALLEL_THRESHOLD {
+            // Parallel encoding for large batches
+            let encoded: Vec<_> = points
+                .par_iter()
+                .map(|point| {
+                    let key = point.id.encode()?;
+                    let value = point.encode_payload()?;
+                    Ok((key, value, point.id.clone()))
+                })
+                .collect::<Result<Vec<_>, StorageError>>()?;
+
+            for (key, value, id) in encoded {
+                self.db.insert(key, value).map_err(|e| {
+                    StorageError::ServiceError(format!(
+                        "Failed to insert point into segment db: {e}"
+                    ))
+                })?;
+                point_ids.push(id);
+            }
+        } else {
+            // Sequential for small batches
+            for point in points {
+                let key = point.id.encode()?;
+                let value = point.encode_payload()?;
+                self.db.insert(key, value).map_err(|e| {
+                    StorageError::ServiceError(format!(
+                        "Failed to insert point into segment db: {e}"
+                    ))
+                })?;
+                point_ids.push(point.id.clone());
+            }
         }
 
-        let point_ids = points
-            .iter()
-            .map(|point| point.id.clone())
-            .collect::<Vec<_>>();
         self.queue_for_indexing(point_ids)?;
 
         self.db


### PR DESCRIPTION
Mainly 3 improvements:
- Do tokenization in text index in parallel
- Do encoding in payload index in parallel if there are >= 500 points
- Run indexing on each index in parallel if there are >=3 indices