### PR TITLE
Isolate payload index benches

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -67,6 +67,7 @@ jobs:
               echo "Checking out base commit $BASE_SHA to generate baseline..."
               git checkout "$BASE_SHA"
               cargo bench --bench collection -- --save-baseline main || true
+              cargo bench --bench index -- --save-baseline main || true
 
               echo "Switching back to PR commit $PR_SHA..."
               git checkout "$PR_SHA"
@@ -83,6 +84,7 @@ jobs:
               echo "Previous commit detected: $PREV_SHA. Generating baseline from it..."
               git checkout "$PREV_SHA"
               cargo bench --bench collection -- --save-baseline main || true
+              cargo bench --bench index -- --save-baseline main || true
 
               echo "Switching back to current commit $CURRENT_SHA..."
               git checkout "$CURRENT_SHA"
@@ -95,12 +97,14 @@ jobs:
           if [ "$BASELINE_EXISTS" = "false" ]; then
             echo "⚠️ No baseline available. Running benchmarks and saving baseline for future runs..."
             cargo bench --bench collection -- --save-baseline main 2>&1 | tee bench_output.txt || true
+            cargo bench --bench index -- --save-baseline main 2>&1 | tee -a bench_output.txt || true
             echo "baseline_missing=true" >> $GITHUB_OUTPUT
             echo "exit_code=0" >> $GITHUB_OUTPUT
           else
             echo "📊 Running benchmarks with baseline comparison..."
             # Run with baseline comparison - Criterion will show differences
             cargo bench --bench collection -- --baseline main 2>&1 | tee bench_output.txt || true
+            cargo bench --bench index -- --baseline main 2>&1 | tee -a bench_output.txt || true
             BENCH_EXIT_CODE=${PIPESTATUS[0]}
             echo "exit_code=$BENCH_EXIT_CODE" >> $GITHUB_OUTPUT
             echo "baseline_missing=false" >> $GITHUB_OUTPUT
@@ -109,6 +113,7 @@ jobs:
             echo "" >> bench_output.txt
             echo "=== Threshold Check (5% significance) ===" >> bench_output.txt
             cargo bench --bench collection -- --baseline main --test 2>&1 | tee -a bench_output.txt || true
+            cargo bench --bench index -- --baseline main --test 2>&1 | tee -a bench_output.txt || true
           fi
 
           # Kill monitor

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,10 @@ lto = false
 name = "collection"
 harness = false
 
+[[bench]]
+name = "index"
+harness = false
+
 [profile.perf] # for profiling
 inherits = "release"
 debug = 2

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -15,9 +15,15 @@ grpcurl -plaintext -import-path src/api/grpc/proto/ -proto smoldb.proto 0.0.0.0:
 ### Comparing feature branch to dev
 
 ```sh
+# Collection benchmarks (write, read, query, text_search - requires full Collection setup)
 cargo bench --bench collection -- --save-baseline dev
 git checkout feat-branch
 cargo bench --bench collection -- --baseline dev
+
+# Index benchmarks (IntegerIndex, TextIndex - lightweight, no Collection needed)
+cargo bench --bench index -- --save-baseline dev
+git checkout feat-branch
+cargo bench --bench index -- --baseline dev
 ```
 
 ### smolbench
@@ -37,8 +43,10 @@ watch -n1 'cargo run -p smolbench --  --skip-write -n 100M --delay 1000 -b 100'
 ```bash
 cargo bench -- --list # List benches
 cargo bench # Run all benches
-cargo bench --bench collection # Run all collection benches
+cargo bench --bench collection # Run all collection benches (write, read, query, text_search)
 cargo bench --bench collection -- read # Run all collection benches with substring 'read'
+cargo bench --bench index # Run all index benches (IntegerIndex, TextIndex)
+cargo bench --bench index -- text # Run index benches with substring 'text'
 
 # Access the reports at `target/criterion/report/index.html`
 python -m http.server target/criterion

--- a/benches/collection/main.rs
+++ b/benches/collection/main.rs
@@ -1,5 +1,4 @@
 mod common;
-mod index;
 mod query;
 mod read;
 mod text_search;
@@ -10,6 +9,6 @@ use criterion::{criterion_group, criterion_main, Criterion};
 criterion_group!(
     name = benches;
     config = Criterion::default();
-    targets = write::write, read::read, query::int_query, text_search::text_query, index::int_indexing, index::text_indexing
+    targets = write::write, read::read, query::int_query, text_search::text_query
 );
 criterion_main!(benches);

--- a/benches/index.rs
+++ b/benches/index.rs
@@ -1,31 +1,66 @@
-use crate::common::{
-    benchmark_group, create_temp_db, generate_integer_values, generate_text_values, BATCH_SIZE,
-};
-use criterion::Criterion;
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion};
+use serde_json::Value;
 use smoldb::storage::index::{
     integer::IntegerIndex, payload_index::FieldIndexTrait, text::TextIndex,
 };
+use tempfile::TempDir;
 
-// Todo: payload_index should have dedicated benches binary that's not part of collection benches?
+const BATCH_SIZE: usize = 1000;
+
+/// Creates a benchmark group with default configuration
+fn benchmark_group<'a>(
+    c: &'a mut Criterion,
+    name: &str,
+) -> BenchmarkGroup<'a, criterion::measurement::WallTime> {
+    let mut group = c.benchmark_group(name);
+    group.sample_size(100);
+    group.measurement_time(Duration::from_secs(5));
+    group.warm_up_time(Duration::from_secs(3));
+    group.significance_level(0.05);
+    group.noise_threshold(0.05);
+    group
+}
+
+/// Creates a temporary database for benchmark storage
+fn create_temp_db() -> (sled::Db, TempDir) {
+    let tempdir = TempDir::new().expect("Failed to create temporary directory");
+    let db = sled::open(tempdir.path()).unwrap();
+    (db, tempdir)
+}
+
+/// Generates integer values for indexing benchmarks
+fn generate_integer_values(num_points: usize) -> Vec<Value> {
+    (0..num_points)
+        .map(|i| Value::Number((i as i64 * 10).into()))
+        .collect()
+}
+
+/// Generates text values for indexing benchmarks
+fn generate_text_values(num_points: usize) -> Vec<Value> {
+    (0..num_points)
+        .map(|i| Value::String(format!("foo bar {}", i)))
+        .collect()
+}
 
 // Integer index benchmarks
 
 pub fn int_indexing(c: &mut Criterion) {
     let mut group = benchmark_group(c, "index/int");
 
-    // For now only upserting BATCH_SIZE points at a time, but must upsert NUM_POINTS points in future
-    // once indexing is faster due to batching.
     let num_points = BATCH_SIZE as u64;
     let point_ids: Vec<u64> = (0..num_points).collect();
     let values = generate_integer_values(num_points as usize);
 
+    // For now only upserting BATCH_SIZE points at a time, but must upsert NUM_POINTS points in future
+    // once indexing is faster due to batching.
     {
         let (db, _tempdir) = create_temp_db();
         let index = IntegerIndex::open(&db, "price", false).unwrap();
 
         group.bench_function("batch", |b| {
             b.iter(|| {
-                // todo: Add batching
                 index.add_points(&point_ids, &values).unwrap();
             });
         });
@@ -48,18 +83,17 @@ pub fn int_indexing(c: &mut Criterion) {
 pub fn text_indexing(c: &mut Criterion) {
     let mut group = benchmark_group(c, "index/text");
 
-    // For now only upserting BATCH_SIZE points at a time, but must upsert NUM_POINTS points in future
-    // once indexing is faster due to batching.
     let num_points = BATCH_SIZE as u64;
     let point_ids: Vec<u64> = (0..num_points).collect();
     let values = generate_text_values(num_points as usize);
 
+    // For now only upserting BATCH_SIZE points at a time, but must upsert NUM_POINTS points in future
+    // once indexing is faster due to batching.
     group.bench_function("batch", |b| {
         let (db, _tempdir) = create_temp_db();
         let index = TextIndex::open(&db, "description", false).unwrap();
 
         b.iter(|| {
-            // todo: Add batching
             index.add_points(&point_ids, &values).unwrap();
         });
     });
@@ -69,8 +103,14 @@ pub fn text_indexing(c: &mut Criterion) {
         let index_with_in_mem = TextIndex::open(&db, "description", true).unwrap();
 
         b.iter(|| {
-            // todo: Add batching
             index_with_in_mem.add_points(&point_ids, &values).unwrap();
         });
     });
 }
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = int_indexing, text_indexing
+);
+criterion_main!(benches);


### PR DESCRIPTION
As I suspected, all the benches are registered and their initialization code is run (and probably kept in memory even after the benches are done running). That's why when even you try to run `index` benches, local shard is initialized (and filled with points) and if you put panic in local shard init/load, benches will panic. This is so annoying thing about criterion. It leads to slower benches (doesn't affect measure time though) and constantly growing memory in CI while benches are running. 

Although, this isn't the right solution either. I'll think more about it. I don't want to pollute my `Cargo.toml` with benches for everything. Would be very annoying.

Related https://github.com/KShivendu/smoldb/issues/103