### PR TITLE
Add interface for vector index

### DIFF
--- a/src/storage/segment/index/mod.rs
+++ b/src/storage/segment/index/mod.rs
@@ -2,3 +2,4 @@ pub mod filter;
 pub mod integer;
 pub mod payload_index;
 pub mod text;
+pub mod vector;

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -153,26 +153,6 @@ impl FieldIndexTrait<&Value> for FieldIndex {
 
                 vector_index.query(&vector, operation, limit)?
             }
-            FieldIndex::Vector(vector_index) => {
-                let value = value.as_array().ok_or_else(|| {
-                    StorageError::BadInput(format!(
-                        "Vector index query value must be an array. Found {value}"
-                    ))
-                })?;
-
-                let vector = value
-                    .iter()
-                    .map(|v| {
-                        v.as_f64().ok_or_else(|| {
-                            StorageError::BadInput(format!(
-                        "Vector index query value must be an array of numbers. Found {value:?}"
-                    ))
-                        })
-                    })
-                    .collect::<StorageResult<Vec<VectorDataType>>>()?;
-
-                vector_index.query(&vector, operation, limit)?
-            }
         };
 
         Ok(results)

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -2,7 +2,12 @@ use crate::{
     api::points::Query,
     error::{StorageError, StorageResult},
     storage::{
-        index::{filter::FilterOperator, integer::IntegerIndex, text::TextIndex},
+        index::{
+            filter::FilterOperator,
+            integer::IntegerIndex,
+            text::TextIndex,
+            vector::{VectorDataType, VectorIndex},
+        },
         segment::{Point, PointId},
     },
 };
@@ -39,6 +44,7 @@ pub fn decoded_point_ids(data: &[u8]) -> StorageResult<Vec<u64>> {
 pub enum FieldIndex {
     Int(IntegerIndex),
     Text(TextIndex),
+    Vector(VectorIndex),
     Null,
 }
 
@@ -47,6 +53,7 @@ pub enum FieldIndex {
 pub enum IndexConfig {
     Int,
     Text,
+    Vector,
     Null,
 }
 
@@ -60,6 +67,11 @@ impl FieldIndex {
         let index = TextIndex::open(db, name, true)?;
         Ok(FieldIndex::Text(index))
     }
+
+    pub fn new_vector(db: &Db, name: &str) -> StorageResult<Self> {
+        let index = VectorIndex::open(db, name, true)?;
+        Ok(FieldIndex::Vector(index))
+    }
 }
 
 impl FieldIndexTrait<&Value> for FieldIndex {
@@ -67,6 +79,7 @@ impl FieldIndexTrait<&Value> for FieldIndex {
         match self {
             FieldIndex::Int(index) => index.add_point(point_id, value),
             FieldIndex::Text(index) => index.add_point(point_id, value),
+            FieldIndex::Vector(index) => index.add_point(point_id, value),
             FieldIndex::Null => Err(StorageError::BadInput(
                 "Null index is not supported yet".to_string(),
             )),
@@ -77,6 +90,7 @@ impl FieldIndexTrait<&Value> for FieldIndex {
         match self {
             FieldIndex::Int(index) => index.add_points(point_ids, values),
             FieldIndex::Text(index) => index.add_points(point_ids, values),
+            FieldIndex::Vector(index) => index.add_points(point_ids, values),
             FieldIndex::Null => Err(StorageError::BadInput(
                 "Null index is not supported yet".to_string(),
             )),
@@ -119,6 +133,46 @@ impl FieldIndexTrait<&Value> for FieldIndex {
 
                 text_index.query(value, &FilterOperator::Eq, limit)?
             }
+            FieldIndex::Vector(vector_index) => {
+                let value = value.as_array().ok_or_else(|| {
+                    StorageError::BadInput(format!(
+                        "Vector index query value must be an array. Found {value}"
+                    ))
+                })?;
+
+                let vector = value
+                    .iter()
+                    .map(|v| {
+                        v.as_f64().ok_or_else(|| {
+                            StorageError::BadInput(format!(
+                        "Vector index query value must be an array of numbers. Found {value:?}"
+                    ))
+                        })
+                    })
+                    .collect::<StorageResult<Vec<VectorDataType>>>()?;
+
+                vector_index.query(&vector, operation, limit)?
+            }
+            FieldIndex::Vector(vector_index) => {
+                let value = value.as_array().ok_or_else(|| {
+                    StorageError::BadInput(format!(
+                        "Vector index query value must be an array. Found {value}"
+                    ))
+                })?;
+
+                let vector = value
+                    .iter()
+                    .map(|v| {
+                        v.as_f64().ok_or_else(|| {
+                            StorageError::BadInput(format!(
+                        "Vector index query value must be an array of numbers. Found {value:?}"
+                    ))
+                        })
+                    })
+                    .collect::<StorageResult<Vec<VectorDataType>>>()?;
+
+                vector_index.query(&vector, operation, limit)?
+            }
         };
 
         Ok(results)
@@ -149,6 +203,7 @@ impl PayloadIndex {
                     ))
                 }
                 IndexConfig::Text => FieldIndex::new_text(db, &name),
+                IndexConfig::Vector => FieldIndex::new_vector(db, &name),
             }?;
             indices.insert(name, field_index);
         }
@@ -180,6 +235,7 @@ impl PayloadIndex {
                 ))
             }
             IndexConfig::Text => FieldIndex::new_text(db, name)?,
+            IndexConfig::Vector => FieldIndex::new_vector(db, name)?,
         };
 
         let index_config_str =

--- a/src/storage/segment/index/vector.rs
+++ b/src/storage/segment/index/vector.rs
@@ -1,0 +1,36 @@
+use serde_json::Value;
+
+use crate::{
+    error::StorageResult,
+    storage::{
+        index::{filter::FilterOperator, payload_index::FieldIndexTrait},
+        segment::PointId,
+    },
+};
+
+pub type VectorDataType = f64;
+
+pub struct VectorIndex {}
+
+impl FieldIndexTrait<&[VectorDataType]> for VectorIndex {
+    fn open(_db: &sled::Db, _name: &str, _use_in_memory: bool) -> StorageResult<Self> {
+        Ok(VectorIndex {})
+    }
+
+    fn add_point(&self, _point_id: u64, _value: &Value) -> StorageResult<()> {
+        Ok(())
+    }
+
+    fn add_points(&self, _point_ids: &[u64], _values: &[Value]) -> StorageResult<()> {
+        Ok(())
+    }
+
+    fn query(
+        &self,
+        _value: &[VectorDataType],
+        _operation: &FilterOperator,
+        _limit: Option<usize>,
+    ) -> StorageResult<Vec<PointId>> {
+        Ok(Vec::new())
+    }
+}

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -2,6 +2,7 @@ use crate::error::SmolBenchError;
 use crate::types::{ApiResponse, ApiSuccessResponse, Point, PointId, Points};
 use http::Uri;
 use indicatif::ProgressStyle;
+use rand::Rng;
 use serde_json::{json, Value};
 use std::time::Duration;
 use tokio::time::sleep;
@@ -197,6 +198,11 @@ pub async fn delete_collection(
     Ok(())
 }
 
+fn random_vector(dim: usize) -> Vec<f32> {
+    let mut rng = rand::rng();
+    (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<_>>()
+}
+
 pub async fn upsert_points(
     url: &Uri,
     collection_name: &str,
@@ -228,6 +234,7 @@ pub async fn upsert_points(
                     "description": format!("Point {}", i),
                     "price": i as i64 * 10,
                     "timestamp": batch_ts.to_rfc3339(),
+                    "vector": random_vector(10)
                 }),
             })
             .collect();

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -64,6 +64,7 @@ pub async fn create_collection(
     collection_name: &str,
     skip_int_index: bool,
     skip_text_index: bool,
+    skip_vector_index: bool,
     wait: bool,
 ) -> Result<ApiSuccessResponse<bool>, SmolBenchError> {
     // First ensure that consensus is started
@@ -77,6 +78,9 @@ pub async fn create_collection(
     }
     if !skip_text_index {
         payload_schema["description"] = json!("text");
+    }
+    if !skip_vector_index {
+        payload_schema["vector"] = json!("vector");
     }
 
     let res = client

--- a/tools/smolbench/src/args.rs
+++ b/tools/smolbench/src/args.rs
@@ -59,10 +59,15 @@ pub struct Args {
     #[clap(long, default_value = "false")]
     pub skip_int_index: bool,
 
-    // ToDo: Remove this flag once text index is faster or decoupled
+    // ToDo: Change to false once text index is faster or decoupled
     /// Use text index for payload
     #[clap(long, default_value = "true")]
     pub skip_text_index: bool,
+
+    // ToDo: Change to false once vector index is faster or decoupled
+    /// Use vector index for payload
+    #[clap(long, default_value = "false")]
+    pub skip_vector_index: bool,
 
     /// Use if you don't want to upsert points by default
     #[clap(long, default_value = "false")]

--- a/tools/smolbench/src/args.rs
+++ b/tools/smolbench/src/args.rs
@@ -66,7 +66,7 @@ pub struct Args {
 
     // ToDo: Change to false once vector index is faster or decoupled
     /// Use vector index for payload
-    #[clap(long, default_value = "false")]
+    #[clap(long, default_value = "true")]
     pub skip_vector_index: bool,
 
     /// Use if you don't want to upsert points by default

--- a/tools/smolbench/src/main.rs
+++ b/tools/smolbench/src/main.rs
@@ -48,6 +48,7 @@ async fn main() -> Result<(), SmolBenchError> {
                     &args.collection_name,
                     args.skip_int_index,
                     args.skip_text_index,
+                    args.skip_vector_index,
                     true,
                 )
                 .await
@@ -66,6 +67,7 @@ async fn main() -> Result<(), SmolBenchError> {
                 &args.collection_name,
                 args.skip_int_index,
                 args.skip_text_index,
+                args.skip_vector_index,
                 true,
             )
             .await

--- a/tools/smolbench/src/tests/mod.rs
+++ b/tools/smolbench/src/tests/mod.rs
@@ -17,7 +17,7 @@ async fn test_smoldb_consecutive_writes() -> Result<(), crate::error::SmolBenchE
     let delay = None;
 
     let create_response =
-        crate::apis::create_collection(&uri, &collection_name, false, false, true).await?;
+        crate::apis::create_collection(&uri, &collection_name, false, false, false, true).await?;
 
     println!("Result: {}", &create_response.result);
     assert!(create_response.result);


### PR DESCRIPTION
Basic interface to upsert dense and payload schema type to detect it.

```http 
PUT /collections/benchmark
{
   "params": "..."
   "payload_schema": {
      // ...
      "vector": "vector"
    }
}

PUT /collections/benchmark/points
{
  "points": [
    {
      "id": 123,
      "payload": {
        "msg": "Hi there 123",
        "price": 1000,
        "vector": [0.1, -0.5, 0.2, 0.5]
      }
    }
  ]
}
```

