### PR TITLE
Vector index query

### DIFF
--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -91,6 +91,20 @@ pub fn generate_points(num_points: u64) -> Vec<Point> {
         .collect()
 }
 
+/// Generates points with IDs from 0 to num_points-1 and payloads of the form "Hello world {id}", price, and vector of dimension 4
+pub fn generate_points_with_vector(num_points: u64, dim: usize) -> Vec<Point> {
+    (0..num_points)
+        .map(|id| Point {
+            id: PointId::Id(id),
+            payload: json!({
+                TEXT_FIELD: format!("Hello world {}", id),
+                INT_FIELD: id as i64 * 10,
+                VECTOR_FIELD: random_vector(dim),
+            }),
+        })
+        .collect()
+}
+
 /// todo: not used in the benchmarks yet
 /// Generates a random point with a random ID and payload
 #[allow(dead_code)]

--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -85,7 +85,6 @@ pub fn generate_points(num_points: u64) -> Vec<Point> {
             payload: json!({
                 TEXT_FIELD: format!("Hello world {}", id),
                 INT_FIELD: id as i64 * 10,
-                VECTOR_FIELD: random_vector(4),
             }),
         })
         .collect()

--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -223,3 +223,8 @@ pub fn generate_text_values(num_points: usize) -> Vec<Value> {
         .map(|i| Value::String(format!("foo bar {}", i)))
         .collect()
 }
+
+/// Generates vector values for indexing benchmarks
+pub fn generate_vector_values(num_points: usize, dim: usize) -> Vec<Value> {
+    (0..num_points).map(|_| json!(random_vector(dim))).collect()
+}

--- a/benches/collection/common.rs
+++ b/benches/collection/common.rs
@@ -30,6 +30,7 @@ pub const CONCURRENCY: usize = 16;
 
 pub const TEXT_FIELD: &str = "description";
 pub const INT_FIELD: &str = "price";
+pub const VECTOR_FIELD: &str = "vector";
 
 /// Creates a new multi-threaded tokio runtime for benchmarks
 pub fn create_runtime() -> Runtime {
@@ -71,12 +72,21 @@ pub async fn create_collection(
     .unwrap()
 }
 
+/// Generate random vector
+pub fn random_vector(dim: usize) -> Vec<f64> {
+    (0..dim).map(|_| rand::random::<f64>()).collect()
+}
+
 /// Generates points with IDs from 0 to num_points-1 and payloads of the form "Hello world {id}"
 pub fn generate_points(num_points: u64) -> Vec<Point> {
     (0..num_points)
         .map(|id| Point {
             id: PointId::Id(id),
-            payload: json!({ TEXT_FIELD: format!("Hello world {}", id), INT_FIELD: id as i64 * 10 }),
+            payload: json!({
+                TEXT_FIELD: format!("Hello world {}", id),
+                INT_FIELD: id as i64 * 10,
+                VECTOR_FIELD: random_vector(4),
+            }),
         })
         .collect()
 }
@@ -115,6 +125,20 @@ pub fn generate_text_queries(num_queries: usize) -> Vec<Query> {
             filter: QueryFilter::new(
                 TEXT_FIELD,
                 Value::from(format!("Hello world {}", i)),
+                FilterOperator::Eq,
+            ),
+            limit: Some(10),
+        })
+        .collect::<Vec<_>>()
+}
+
+/// Generate queries for vector index
+pub fn generate_vector_queries(num_queries: usize) -> Vec<Query> {
+    (0..num_queries)
+        .map(|_| Query {
+            filter: QueryFilter::new(
+                VECTOR_FIELD,
+                Value::from(random_vector(4)),
                 FilterOperator::Eq,
             ),
             limit: Some(10),

--- a/benches/collection/index.rs
+++ b/benches/collection/index.rs
@@ -1,9 +1,10 @@
 use crate::common::{
-    benchmark_group, create_temp_db, generate_integer_values, generate_text_values, BATCH_SIZE,
+    benchmark_group, create_temp_db, generate_integer_values, generate_text_values,
+    generate_vector_values, BATCH_SIZE,
 };
 use criterion::Criterion;
 use smoldb::storage::index::{
-    integer::IntegerIndex, payload_index::FieldIndexTrait, text::TextIndex,
+    integer::IntegerIndex, payload_index::FieldIndexTrait, text::TextIndex, vector::VectorIndex,
 };
 
 // Todo: payload_index should have dedicated benches binary that's not part of collection benches?
@@ -69,6 +70,42 @@ pub fn text_indexing(c: &mut Criterion) {
     {
         let (db, _tempdir) = create_temp_db();
         let index_with_in_mem = TextIndex::open(&db, "description", true).unwrap();
+
+        group.bench_function("in_memory/batch", |b| {
+            b.iter(|| {
+                // todo: Add batching
+                index_with_in_mem.add_points(&point_ids, &values).unwrap();
+            });
+        });
+    }
+}
+
+// Vector index benchmarks
+
+pub fn vector_indexing(c: &mut Criterion) {
+    let mut group = benchmark_group(c, "index/vector");
+
+    // For now only upserting BATCH_SIZE points at a time, but must upsert NUM_POINTS points in future
+    // once indexing is faster due to batching.
+    let num_points = BATCH_SIZE as u64;
+    let point_ids: Vec<u64> = (0..num_points).collect();
+    let values = generate_vector_values(num_points as usize, 4);
+
+    {
+        let (db, _tempdir) = create_temp_db();
+        let index = VectorIndex::open(&db, "vector", false).unwrap();
+
+        group.bench_function("batch", |b| {
+            b.iter(|| {
+                // todo: Add batching
+                index.add_points(&point_ids, &values).unwrap();
+            });
+        });
+    }
+
+    {
+        let (db, _tempdir) = create_temp_db();
+        let index_with_in_mem = VectorIndex::open(&db, "vector", true).unwrap();
 
         group.bench_function("in_memory/batch", |b| {
             b.iter(|| {

--- a/benches/collection/main.rs
+++ b/benches/collection/main.rs
@@ -11,6 +11,6 @@ use criterion::{criterion_group, criterion_main, Criterion};
 criterion_group!(
     name = benches;
     config = Criterion::default();
-    targets = write::write, read::read, query::int_query, text_search::text_query, index::int_indexing, index::text_indexing, vector_search::vector_query
+    targets = write::write, read::read, query::int_query, text_search::text_query, index::int_indexing, index::text_indexing, vector_search::vector_query, index::vector_indexing
 );
 criterion_main!(benches);

--- a/benches/collection/main.rs
+++ b/benches/collection/main.rs
@@ -3,6 +3,7 @@ mod index;
 mod query;
 mod read;
 mod text_search;
+mod vector_search;
 mod write;
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -10,6 +11,6 @@ use criterion::{criterion_group, criterion_main, Criterion};
 criterion_group!(
     name = benches;
     config = Criterion::default();
-    targets = write::write, read::read, query::int_query, text_search::text_query, index::int_indexing, index::text_indexing
+    targets = write::write, read::read, query::int_query, text_search::text_query, index::int_indexing, index::text_indexing, vector_search::vector_query
 );
 criterion_main!(benches);

--- a/benches/collection/vector_search.rs
+++ b/benches/collection/vector_search.rs
@@ -1,7 +1,7 @@
 use crate::common::{
     benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
-    create_tempdir, generate_points, generate_vector_queries, CONCURRENCY, NUM_POINTS_INDEXING,
-    NUM_QUERIES, VECTOR_FIELD,
+    create_tempdir, generate_points_with_vector, generate_vector_queries, CONCURRENCY,
+    NUM_POINTS_INDEXING, NUM_QUERIES, VECTOR_FIELD,
 };
 use criterion::{Criterion, Throughput};
 use futures::stream::{self, StreamExt};
@@ -25,7 +25,7 @@ pub fn vector_query(c: &mut Criterion) {
                 &tempdir,
                 channel_service,
                 Some(payload_index),
-                generate_points(NUM_POINTS_INDEXING),
+                generate_points_with_vector(NUM_POINTS_INDEXING, 4),
                 true, // Wait for indexing to complete
             )
             .await
@@ -52,7 +52,7 @@ pub fn vector_query(c: &mut Criterion) {
                 &tempdir,
                 channel_service,
                 Some(payload_index),
-                generate_points(NUM_POINTS_INDEXING),
+                generate_points_with_vector(NUM_POINTS_INDEXING, 4),
                 true, // Wait for indexing to complete
             )
             .await

--- a/benches/collection/vector_search.rs
+++ b/benches/collection/vector_search.rs
@@ -1,0 +1,81 @@
+use crate::common::{
+    benchmark_group, create_channel_service, create_collection_with_points, create_runtime,
+    create_tempdir, generate_points, generate_vector_queries, CONCURRENCY, NUM_POINTS_INDEXING,
+    NUM_QUERIES, VECTOR_FIELD,
+};
+use criterion::{Criterion, Throughput};
+use futures::stream::{self, StreamExt};
+use smoldb::storage::index::payload_index::IndexConfig;
+use std::{collections::BTreeMap, sync::Arc};
+
+// Perf when bench was first implemented: single=1.5804 µs, concurrent=5.7696 µs
+pub fn vector_query(c: &mut Criterion) {
+    let mut group = benchmark_group(c, "query/vector");
+    let rt = create_runtime();
+
+    // Single vector query benchmark
+    {
+        let query = generate_vector_queries(1).first().unwrap().clone();
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let collection = rt.block_on(async {
+            let payload_index =
+                BTreeMap::from_iter([(VECTOR_FIELD.to_string(), IndexConfig::Vector)]);
+            create_collection_with_points(
+                &tempdir,
+                channel_service,
+                Some(payload_index),
+                generate_points(NUM_POINTS_INDEXING),
+                true, // Wait for indexing to complete
+            )
+            .await
+        });
+
+        group.bench_function("single", |b| {
+            b.to_async(&rt).iter(|| async {
+                collection.query_points(query.clone(), true).await.unwrap();
+            });
+        });
+    }
+
+    // todo: Query a single batch of RW_BATCH_SIZE points while there are NUM_POINTS points in the collection
+    // It needs support from the API to pass a batch of queries
+
+    {
+        let queries = generate_vector_queries(NUM_QUERIES);
+        let tempdir = create_tempdir();
+        let channel_service = create_channel_service();
+        let collection = rt.block_on(async {
+            let payload_index =
+                BTreeMap::from_iter([(VECTOR_FIELD.to_string(), IndexConfig::Vector)]);
+            create_collection_with_points(
+                &tempdir,
+                channel_service,
+                Some(payload_index),
+                generate_points(NUM_POINTS_INDEXING),
+                true, // Wait for indexing to complete
+            )
+            .await
+        });
+
+        // ToDo: Ensure that all points have been indexed before querying?
+
+        let collection_arc = Arc::new(collection);
+
+        // For querying, batch size is always 1 (for now)
+        // So we can just run NUM_QUERIES queries in CONCURRENCY parallel with batch size=1
+        group.throughput(Throughput::Elements(NUM_QUERIES as u64));
+        group.bench_function("concurrent", |b| {
+            b.to_async(&rt).iter(|| async {
+                stream::iter(queries.clone())
+                    .map(|query| {
+                        let collection_clone = collection_arc.clone();
+                        async move { collection_clone.query_points(query, true).await.unwrap() }
+                    })
+                    .buffer_unordered(CONCURRENCY)
+                    .collect::<Vec<_>>()
+                    .await;
+            });
+        });
+    }
+}

--- a/src/storage/segment/index/payload_index.rs
+++ b/src/storage/segment/index/payload_index.rs
@@ -6,7 +6,7 @@ use crate::{
             filter::FilterOperator,
             integer::IntegerIndex,
             text::TextIndex,
-            vector::{VectorDataType, VectorIndex},
+            vector::{DimType, VectorIndex},
         },
         segment::{Point, PointId},
     },
@@ -149,7 +149,7 @@ impl FieldIndexTrait<&Value> for FieldIndex {
                     ))
                         })
                     })
-                    .collect::<StorageResult<Vec<VectorDataType>>>()?;
+                    .collect::<StorageResult<Vec<DimType>>>()?;
 
                 vector_index.query(&vector, operation, limit)?
             }

--- a/src/storage/segment/index/vector.rs
+++ b/src/storage/segment/index/vector.rs
@@ -1,6 +1,5 @@
 use serde_json::Value;
 use std::cmp::Ordering;
-use std::cmp::Ordering;
 
 use crate::{
     error::{StorageError, StorageResult},

--- a/src/storage/segment/index/vector.rs
+++ b/src/storage/segment/index/vector.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use std::cmp::Ordering;
+use std::{cmp::Ordering, collections::HashMap, sync::RwLock};
 
 use crate::{
     error::{StorageError, StorageResult},
@@ -12,17 +12,23 @@ use crate::{
     },
 };
 
-pub type VectorDataType = f64;
+pub type DimType = f64;
 
 pub struct VectorIndex {
     tree: sled::Tree,
+    in_memory: Option<RwLock<InMemoryVectorIndex>>,
 }
 
-impl FieldIndexTrait<&[VectorDataType]> for VectorIndex {
-    fn open(db: &sled::Db, name: &str, _use_in_memory: bool) -> StorageResult<Self> {
+impl FieldIndexTrait<&[DimType]> for VectorIndex {
+    fn open(db: &sled::Db, name: &str, use_in_memory: bool) -> StorageResult<Self> {
         // Todo: Take dimension as an argument via payload index config
         let tree = db.open_tree(format!("{name}_vector_index"))?;
-        Ok(VectorIndex { tree })
+        let in_memory = if use_in_memory {
+            Some(RwLock::new(InMemoryVectorIndex::new(&tree)?))
+        } else {
+            None
+        };
+        Ok(VectorIndex { tree, in_memory })
     }
 
     fn add_point(&self, point_id: u64, value: &Value) -> StorageResult<()> {
@@ -38,11 +44,21 @@ impl FieldIndexTrait<&[VectorDataType]> for VectorIndex {
                     ))
                 })
             })
-            .collect::<StorageResult<Vec<VectorDataType>>>()?;
+            .collect::<StorageResult<Vec<DimType>>>()?;
 
         let encoded_point_ids = encoded_point_ids(&[point_id])?;
         let encoded_vector = encode_vector(&vector)?;
         self.tree.insert(encoded_point_ids, encoded_vector)?;
+
+        if let Some(in_memory) = &self.in_memory {
+            let mut guard = in_memory.write().map_err(|e| {
+                StorageError::ServiceError(format!(
+                    "Failed to write to in-memory vector index: {e}"
+                ))
+            })?;
+            guard.insert(point_id, vector)?;
+        }
+
         Ok(())
     }
 
@@ -55,16 +71,28 @@ impl FieldIndexTrait<&[VectorDataType]> for VectorIndex {
 
     fn query(
         &self,
-        query: &[VectorDataType],
+        query: &[DimType],
         _operation: &FilterOperator, // todo: allow specifying distance metric?
         limit: Option<usize>,
     ) -> StorageResult<Vec<PointId>> {
         let mut all_vectors = Vec::new();
-        for result in self.tree.iter() {
-            let (key, value) = result?;
-            let point_id = decoded_point_ids(&key)?[0];
-            let vector = decode_vector(&value)?;
-            all_vectors.push((point_id, vector));
+        if let Some(in_memory) = &self.in_memory {
+            let guard = in_memory.read().map_err(|e| {
+                StorageError::ServiceError(format!(
+                    "Failed to read from in-memory vector index: {e}"
+                ))
+            })?;
+            for (point_id, vector) in guard.iter() {
+                all_vectors.push((*point_id, vector.clone())); // todo: avoid cloning
+            }
+        } else {
+            // Read from disk since we don't have in-memory cache
+            for result in self.tree.iter() {
+                let (key, value) = result?;
+                let point_id = decoded_point_ids(&key)?[0];
+                let vector = decode_vector(&value)?;
+                all_vectors.push((point_id, vector));
+            }
         }
 
         let mut results = Vec::new();
@@ -85,7 +113,33 @@ impl FieldIndexTrait<&[VectorDataType]> for VectorIndex {
     }
 }
 
-fn cosine_similarity(a: &[VectorDataType], b: &[VectorDataType]) -> Result<f64, StorageError> {
+struct InMemoryVectorIndex {
+    index: HashMap<u64, Vec<DimType>>,
+}
+
+impl InMemoryVectorIndex {
+    pub fn new(tree: &sled::Tree) -> StorageResult<Self> {
+        let mut index = HashMap::new();
+        for item in tree.iter() {
+            let (key, value) = item?;
+            let point_id = decoded_point_ids(&key)?[0];
+            let vector = decode_vector(&value)?;
+            index.insert(point_id, vector);
+        }
+        Ok(Self { index })
+    }
+
+    pub fn insert(&mut self, point_id: u64, vector: Vec<DimType>) -> StorageResult<()> {
+        self.index.insert(point_id, vector);
+        Ok(())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&u64, &Vec<DimType>)> {
+        self.index.iter()
+    }
+}
+
+fn cosine_similarity(a: &[DimType], b: &[DimType]) -> Result<f64, StorageError> {
     if a.len() != b.len() {
         return Err(StorageError::BadInput(format!(
             "Vectors must have the same length: {a:?} and {b:?}"
@@ -98,12 +152,12 @@ fn cosine_similarity(a: &[VectorDataType], b: &[VectorDataType]) -> Result<f64, 
     Ok(dot_product / (a_norm * b_norm))
 }
 
-fn encode_vector(vector: &[VectorDataType]) -> StorageResult<Vec<u8>> {
+fn encode_vector(vector: &[DimType]) -> StorageResult<Vec<u8>> {
     bincode::encode_to_vec(vector, bincode::config::standard())
         .map_err(|e| StorageError::CodecError(format!("Failed to encode vector: {e}")))
 }
 
-fn decode_vector(data: &[u8]) -> StorageResult<Vec<VectorDataType>> {
+fn decode_vector(data: &[u8]) -> StorageResult<Vec<DimType>> {
     bincode::decode_from_slice(data, bincode::config::standard())
         .map(|(vector, _)| vector)
         .map_err(|e| StorageError::CodecError(format!("Failed to decode vector: {e}")))

--- a/src/storage/segment/index/vector.rs
+++ b/src/storage/segment/index/vector.rs
@@ -1,36 +1,111 @@
 use serde_json::Value;
+use std::cmp::Ordering;
+use std::cmp::Ordering;
 
 use crate::{
-    error::StorageResult,
+    error::{StorageError, StorageResult},
     storage::{
-        index::{filter::FilterOperator, payload_index::FieldIndexTrait},
+        index::{
+            filter::FilterOperator,
+            payload_index::{decoded_point_ids, encoded_point_ids, FieldIndexTrait},
+        },
         segment::PointId,
     },
 };
 
 pub type VectorDataType = f64;
 
-pub struct VectorIndex {}
+pub struct VectorIndex {
+    tree: sled::Tree,
+}
 
 impl FieldIndexTrait<&[VectorDataType]> for VectorIndex {
-    fn open(_db: &sled::Db, _name: &str, _use_in_memory: bool) -> StorageResult<Self> {
-        Ok(VectorIndex {})
+    fn open(db: &sled::Db, name: &str, _use_in_memory: bool) -> StorageResult<Self> {
+        // Todo: Take dimension as an argument via payload index config
+        let tree = db.open_tree(format!("{name}_vector_index"))?;
+        Ok(VectorIndex { tree })
     }
 
-    fn add_point(&self, _point_id: u64, _value: &Value) -> StorageResult<()> {
+    fn add_point(&self, point_id: u64, value: &Value) -> StorageResult<()> {
+        let value = value.as_array().ok_or_else(|| {
+            StorageError::BadInput(format!("Vector index value must be an array: {value}"))
+        })?;
+        let vector = value
+            .iter()
+            .map(|v| {
+                v.as_f64().ok_or_else(|| {
+                    StorageError::BadInput(format!(
+                        "Vector index value must be an array of numbers: {value:?}"
+                    ))
+                })
+            })
+            .collect::<StorageResult<Vec<VectorDataType>>>()?;
+
+        let encoded_point_ids = encoded_point_ids(&[point_id])?;
+        let encoded_vector = encode_vector(&vector)?;
+        self.tree.insert(encoded_point_ids, encoded_vector)?;
         Ok(())
     }
 
-    fn add_points(&self, _point_ids: &[u64], _values: &[Value]) -> StorageResult<()> {
+    fn add_points(&self, point_ids: &[u64], values: &[Value]) -> StorageResult<()> {
+        for (point_id, value) in point_ids.iter().zip(values.iter()) {
+            self.add_point(*point_id, value)?;
+        }
         Ok(())
     }
 
     fn query(
         &self,
-        _value: &[VectorDataType],
-        _operation: &FilterOperator,
-        _limit: Option<usize>,
+        query: &[VectorDataType],
+        _operation: &FilterOperator, // todo: allow specifying distance metric?
+        limit: Option<usize>,
     ) -> StorageResult<Vec<PointId>> {
-        Ok(Vec::new())
+        let mut all_vectors = Vec::new();
+        for result in self.tree.iter() {
+            let (key, value) = result?;
+            let point_id = decoded_point_ids(&key)?[0];
+            let vector = decode_vector(&value)?;
+            all_vectors.push((point_id, vector));
+        }
+
+        let mut results = Vec::new();
+
+        for (point_id, vector) in all_vectors {
+            let similarity = cosine_similarity(&vector, query)?;
+            results.push((point_id, similarity));
+        }
+
+        results.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal));
+
+        if let Some(limit) = limit {
+            results.truncate(limit);
+        }
+
+        // Todo: return scores as well
+        Ok(results.into_iter().map(|(id, _)| PointId::Id(id)).collect())
     }
+}
+
+fn cosine_similarity(a: &[VectorDataType], b: &[VectorDataType]) -> Result<f64, StorageError> {
+    if a.len() != b.len() {
+        return Err(StorageError::BadInput(format!(
+            "Vectors must have the same length: {a:?} and {b:?}"
+        )));
+    }
+
+    let dot_product = a.iter().zip(b.iter()).map(|(a, b)| a * b).sum::<f64>();
+    let a_norm = a.iter().map(|a| a * a).sum::<f64>().sqrt();
+    let b_norm = b.iter().map(|b| b * b).sum::<f64>().sqrt();
+    Ok(dot_product / (a_norm * b_norm))
+}
+
+fn encode_vector(vector: &[VectorDataType]) -> StorageResult<Vec<u8>> {
+    bincode::encode_to_vec(vector, bincode::config::standard())
+        .map_err(|e| StorageError::CodecError(format!("Failed to encode vector: {e}")))
+}
+
+fn decode_vector(data: &[u8]) -> StorageResult<Vec<VectorDataType>> {
+    bincode::decode_from_slice(data, bincode::config::standard())
+        .map(|(vector, _)| vector)
+        .map_err(|e| StorageError::CodecError(format!("Failed to decode vector: {e}")))
 }

--- a/tools/smolbench/src/apis.rs
+++ b/tools/smolbench/src/apis.rs
@@ -238,7 +238,7 @@ pub async fn upsert_points(
                     "description": format!("Point {}", i),
                     "price": i as i64 * 10,
                     "timestamp": batch_ts.to_rfc3339(),
-                    "vector": random_vector(10)
+                    "vector": random_vector(4)
                 }),
             })
             .collect();


### PR DESCRIPTION
Do brute force comparisons against all vectors on disk. 

Also the storage for vector index is just restoring all vectors which is not optimal. There's no IVF/HNSW for now. Will implement soon.

Here's a benchmark that runs queries of 4 dim vectors against 10k vectors

<img width="1179" height="388" alt="image" src="https://github.com/user-attachments/assets/bac8cbcb-6069-44d1-a3c8-3a7fa4b04f23" />

Indexing benchmark (at this point, there's no dedicated data structure, it just maps point ids to vectors):

<img width="656" height="447" alt="image" src="https://github.com/user-attachments/assets/97f81bda-ce88-4080-9cf7-1a4f7d9787c6" />
