### PR TITLE
Improve BM25 perf with stopwords, caching avg dl, parking_lot Mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2925,6 +2925,7 @@ dependencies = [
  "hashring",
  "http 1.4.0",
  "log",
+ "parking_lot 0.12.5",
  "prost 0.11.9",
  "prost 0.13.5",
  "protobuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ bincode = "2.0.1"
 serde_cbor = "0.11.2"
 uuid = {version = "1.19.0", features = ["v4", "serde"]}
 ahash = "0.8.12"
+parking_lot = "0.12.3"
 
 [build-dependencies]
 tonic-build = "0.13.1"

--- a/src/storage/segment/index/text/bm25.rs
+++ b/src/storage/segment/index/text/bm25.rs
@@ -1,6 +1,5 @@
-use std::sync::RwLock;
-
 use ahash::HashMap;
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -22,14 +21,17 @@ impl BM25Scorer {
     /// Create a new BM25Scorer instance, loading existing stats from sled
     pub fn open(stats_tree: sled::Tree) -> StorageResult<Self> {
         // use serde_cbor to load the stats from the tree
-        let stats = stats_tree
+        let mut stats: Bm25Stats = stats_tree
             .get(STATS_KEY)?
             .map(|data| serde_cbor::from_slice(&data))
             .transpose()
-            .map_err(|e| StorageError::CodecError(format!("Failed to decode BM25 stats: {e}")))?;
+            .map_err(|e| StorageError::CodecError(format!("Failed to decode BM25 stats: {e}")))?
+            .unwrap_or_default();
+        // Recompute cached avg_dl from persisted data
+        stats.recompute_avg_dl();
         Ok(Self {
             stats_tree,
-            bm25_stats: RwLock::new(stats.unwrap_or_default()),
+            bm25_stats: RwLock::new(stats),
         })
     }
 
@@ -43,9 +45,7 @@ impl BM25Scorer {
 
     /// Add or update a single document's stats
     pub fn add_document(&self, doc_id: u64, doc_length: u64) -> StorageResult<()> {
-        let mut stats = self.bm25_stats.write().map_err(|e| {
-            StorageError::ServiceError(format!("Failed to acquire write BM25 stats lock: {e}"))
-        })?;
+        let mut stats = self.bm25_stats.write();
         let old_length = stats.doc_length(doc_id);
         let new_length = doc_length as usize;
 
@@ -57,15 +57,14 @@ impl BM25Scorer {
             stats.total_doc_length += (new_length as f64) - (old_length as f64);
         }
         stats.doc_lengths.insert(doc_id, new_length);
+        stats.recompute_avg_dl();
 
         self.persist(&stats)
     }
 
     /// Add or update multiple documents' stats in batch
     pub fn add_documents(&self, new_doc_lengths: &HashMap<u64, u64>) -> StorageResult<()> {
-        let mut stats = self.bm25_stats.write().map_err(|e| {
-            StorageError::ServiceError(format!("Failed to acquire write BM25 stats lock: {e}"))
-        })?;
+        let mut stats = self.bm25_stats.write();
         for (&doc_id, &new_length) in new_doc_lengths {
             let old_length = stats.doc_length(doc_id);
             let new_length = new_length as usize;
@@ -77,6 +76,7 @@ impl BM25Scorer {
             }
             stats.doc_lengths.insert(doc_id, new_length);
         }
+        stats.recompute_avg_dl();
 
         self.persist(&stats)
     }
@@ -87,16 +87,16 @@ impl BM25Scorer {
         token_postings: &[(usize, &[PostingListItem])], // (df, posting_list) pairs
     ) -> StorageResult<HashMap<u64, f64>> {
         // Rank completely from memory because it's faster
-        let stats = self.bm25_stats.read().map_err(|e| {
-            StorageError::ServiceError(format!("Failed to acquire read BM25 stats lock: {e}"))
-        })?;
+        let stats = self.bm25_stats.read();
+        let avg_dl = stats.cached_avg_dl;
         let mut docs_with_scores: HashMap<u64, f64> = HashMap::default();
 
         for (df, posting_list) in token_postings {
             let idf = stats.calculate_idf(*df);
 
             for item in *posting_list {
-                let tf_component = stats.calculate_tf_component(item.term_freq, item.doc_id);
+                let tf_component =
+                    stats.calculate_tf_component(item.term_freq, item.doc_id, avg_dl);
                 let score = idf * tf_component;
                 *docs_with_scores.entry(item.doc_id).or_insert(0.0) += score;
             }
@@ -110,11 +110,29 @@ impl BM25Scorer {
 pub struct Bm25Stats {
     pub doc_lengths: HashMap<u64, usize>,
     pub total_doc_length: f64,
+    /// Cached average document length to avoid recomputation in hot scoring loop
+    #[serde(skip, default = "default_avg_dl")]
+    pub cached_avg_dl: f64,
     k1: f64,
     b: f64,
 }
 
+fn default_avg_dl() -> f64 {
+    1.0
+}
+
 impl Bm25Stats {
+    /// Recompute and cache the average document length
+    #[inline]
+    pub fn recompute_avg_dl(&mut self) {
+        let num_docs = self.doc_lengths.len();
+        self.cached_avg_dl = if num_docs > 0 {
+            self.total_doc_length / num_docs as f64
+        } else {
+            1.0
+        };
+    }
+
     /// Calculate IDF component for a term given its document frequency
     #[inline]
     pub fn calculate_idf(&self, df: usize) -> f64 {
@@ -123,12 +141,11 @@ impl Bm25Stats {
         ((n - df + 0.5) / (df + 0.5) + 1.0).ln()
     }
 
-    /// Calculate TF component for a document
+    /// Calculate TF component for a document using pre-computed avg_dl
     #[inline]
-    pub fn calculate_tf_component(&self, tf: u64, doc_id: u64) -> f64 {
+    pub fn calculate_tf_component(&self, tf: u64, doc_id: u64, avg_dl: f64) -> f64 {
         let tf = tf as f64;
         let doc_len = self.doc_length(doc_id) as f64;
-        let avg_dl = self.avg_doc_length();
         tf * (self.k1 + 1.0) / (tf + self.k1 * (1.0 - self.b + self.b * (doc_len / avg_dl)))
     }
 
@@ -136,17 +153,6 @@ impl Bm25Stats {
     #[inline]
     pub fn num_docs(&self) -> usize {
         self.doc_lengths.len()
-    }
-
-    /// Get the average document length
-    #[inline]
-    pub fn avg_doc_length(&self) -> f64 {
-        let num_docs = self.num_docs();
-        if num_docs > 0 {
-            self.total_doc_length / num_docs as f64
-        } else {
-            1.0
-        }
     }
 
     /// Get document length for a specific document
@@ -161,6 +167,7 @@ impl Default for Bm25Stats {
         Self {
             doc_lengths: HashMap::default(),
             total_doc_length: 0.0,
+            cached_avg_dl: 1.0,
             k1: DEFAULT_K1,
             b: DEFAULT_B,
         }

--- a/src/storage/segment/index/text/mod.rs
+++ b/src/storage/segment/index/text/mod.rs
@@ -2,7 +2,9 @@ mod bm25;
 mod posting;
 mod tokenizer;
 
-use std::{cmp::Ordering, collections::BinaryHeap, sync::RwLock};
+use std::{cmp::Ordering, collections::BinaryHeap};
+
+use parking_lot::RwLock;
 
 use ahash::HashMap;
 use serde_json::Value;
@@ -62,11 +64,7 @@ impl FieldIndexTrait<&str> for TextIndex {
 
             // Fetch existing posting list for this term
             let mut term_posting_list = if let Some(in_memory_postings) = &self.in_memory_postings {
-                let postings = in_memory_postings.read().map_err(|e| {
-                    StorageError::ServiceError(format!(
-                        "Failed to read from in-memory postings: {e}"
-                    ))
-                })?;
+                let postings = in_memory_postings.read();
                 postings.get(term).cloned().unwrap_or_default()
             } else {
                 self.db
@@ -107,9 +105,7 @@ impl FieldIndexTrait<&str> for TextIndex {
 
         // Update in-memory postings cache if enabled
         if let Some(in_memory_postings) = &self.in_memory_postings {
-            let mut postings = in_memory_postings.write().map_err(|e| {
-                StorageError::ServiceError(format!("Failed to write to in-memory postings: {e}"))
-            })?;
+            let mut postings = in_memory_postings.write();
             for (term, posting_list) in updates {
                 postings.insert(term, posting_list);
             }
@@ -134,9 +130,7 @@ impl FieldIndexTrait<&str> for TextIndex {
             Vec::with_capacity(tokens.len());
 
         if let Some(in_memory_postings) = &self.in_memory_postings {
-            let postings = in_memory_postings.read().map_err(|e| {
-                StorageError::ServiceError(format!("Failed to read from in-memory postings: {e}"))
-            })?;
+            let postings = in_memory_postings.read();
             for token in &tokens {
                 if let Some(posting_list) = postings.get(token) {
                     token_postings.push((posting_list.len(), posting_list.clone()));
@@ -211,11 +205,7 @@ impl FieldIndexTrait<&str> for TextIndex {
         for (term, mut new_posting_list) in temp_index {
             let term_key = term.as_bytes();
             let mut posting_list = if let Some(in_memory_postings) = &self.in_memory_postings {
-                let postings = in_memory_postings.read().map_err(|e| {
-                    StorageError::ServiceError(format!(
-                        "Failed to read from in-memory postings: {e}"
-                    ))
-                })?;
+                let postings = in_memory_postings.read();
                 postings.get(&term).cloned().unwrap_or_default()
             } else {
                 self.db
@@ -244,9 +234,7 @@ impl FieldIndexTrait<&str> for TextIndex {
 
         // Update in-memory postings cache if enabled
         if let Some(in_memory_postings) = &self.in_memory_postings {
-            let mut postings = in_memory_postings.write().map_err(|e| {
-                StorageError::ServiceError(format!("Failed to write to in-memory postings: {e}"))
-            })?;
+            let mut postings = in_memory_postings.write();
             for (term, posting_list) in all_updates {
                 postings.insert(term, posting_list);
             }
@@ -312,12 +300,13 @@ mod tests {
 
     #[test]
     fn test_text_index() {
+        // Note: stop words like "the", "a", "over" are filtered out during indexing
         let docs = [
-            "The quick brown fox jumps over the lazy dog",
-            "The quick brown fox",
-            "Lazy dog sleeps all day",
-            "A fast brown fox leaps over a sleepy dog",
-            "the the",
+            "The quick brown fox jumps over the lazy dog", // terms: quick, brown, fox, jumps, lazy, dog
+            "The quick brown fox",                         // terms: quick, brown, fox
+            "Lazy dog sleeps all day",                     // terms: lazy, dog, sleeps, day
+            "A fast brown fox leaps over a sleepy dog", // terms: fast, brown, fox, leaps, sleepy, dog
+            "database search engine",                   // terms: database, search, engine
         ];
 
         // Test single insert
@@ -363,16 +352,18 @@ mod tests {
             "Batch insert query mismatch"
         );
 
-        // Query for common term "the"
-        let expected_the: Vec<PointId> = vec![
-            PointId::Id(4), // has "the" twice and shorter
-            PointId::Id(0), // has "the" twice
-            PointId::Id(1), // has "the" once
-        ];
+        // Query for stop word "the" should return empty results
+        // (stop words are filtered from both indexing and queries)
         let results = single_index
             .query("the", &FilterOperator::Eq, None)
             .unwrap();
-        assert_eq!(results, expected_the, "Common term query mismatch");
+        assert!(results.is_empty(), "Stop word query should return empty");
+
+        // Query for term that appears in multiple docs
+        let results = single_index
+            .query("brown", &FilterOperator::Eq, None)
+            .unwrap();
+        assert_eq!(results.len(), 3); // docs 0, 1, 3 have "brown"
 
         // Test limit (top-k)
         let results = single_index

--- a/src/storage/segment/index/text/tokenizer.rs
+++ b/src/storage/segment/index/text/tokenizer.rs
@@ -1,12 +1,159 @@
-use ahash::HashMap;
+use std::sync::LazyLock;
 
-// TODO: Add stop words, stemming, etc based on language
-/// Tokenize the text into terms
+use ahash::{HashMap, HashSet};
+
+/// Common English stop words for O(1) lookup, initialized once on first access.
+/// These words have very high document frequency and poor selectivity.
+static STOP_WORDS_SET: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    HashSet::from_iter([
+        // Articles
+        "a",
+        "an",
+        "the",
+        // Pronouns
+        "i",
+        "me",
+        "my",
+        "myself",
+        "we",
+        "our",
+        "ours",
+        "ourselves",
+        "you",
+        "your",
+        "yours",
+        "yourself",
+        "yourselves",
+        "he",
+        "him",
+        "his",
+        "himself",
+        "she",
+        "her",
+        "hers",
+        "herself",
+        "it",
+        "its",
+        "itself",
+        "they",
+        "them",
+        "their",
+        "theirs",
+        "themselves",
+        "what",
+        "which",
+        "who",
+        "whom",
+        "this",
+        "that",
+        "these",
+        "those",
+        // Prepositions
+        "in",
+        "on",
+        "at",
+        "by",
+        "for",
+        "with",
+        "about",
+        "against",
+        "between",
+        "into",
+        "through",
+        "during",
+        "before",
+        "after",
+        "above",
+        "below",
+        "to",
+        "from",
+        "up",
+        "down",
+        "out",
+        "off",
+        "over",
+        "under",
+        // Conjunctions
+        "and",
+        "but",
+        "or",
+        "nor",
+        "so",
+        "yet",
+        "both",
+        "either",
+        "neither",
+        // Common verbs
+        "am",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "have",
+        "has",
+        "had",
+        "having",
+        "do",
+        "does",
+        "did",
+        "doing",
+        "would",
+        "should",
+        "could",
+        "ought",
+        "will",
+        "shall",
+        "can",
+        "may",
+        "might",
+        "must",
+        // Other common words
+        "here",
+        "there",
+        "when",
+        "where",
+        "why",
+        "how",
+        "all",
+        "each",
+        "every",
+        "few",
+        "more",
+        "most",
+        "other",
+        "some",
+        "such",
+        "no",
+        "not",
+        "only",
+        "own",
+        "same",
+        "than",
+        "too",
+        "very",
+        "just",
+        "also",
+        "now",
+        "of",
+        "as",
+        "if",
+        "then",
+        "because",
+        "while",
+        "although",
+        "though",
+    ])
+});
+
+/// Tokenize the text into terms, filtering out stop words
 pub fn tokenize(text: &str) -> Vec<String> {
     text.to_lowercase()
         .split_whitespace()
         .map(|s| s.trim_matches(|c: char| !c.is_alphanumeric()))
-        .filter(|s| !s.is_empty())
+        .filter(|s| !s.is_empty() && !STOP_WORDS_SET.contains(s))
         .map(|s| s.to_string())
         .collect()
 }
@@ -25,6 +172,7 @@ mod tests {
 
     #[test]
     fn test_tokenizer() {
+        // Note: "a" is filtered as a stop word
         assert_eq!(
             tokenize("Hello, world! 123. a1b2c3 hello 123-456-7890"),
             ["hello", "world", "123", "a1b2c3", "hello", "123-456-7890"]
@@ -36,5 +184,24 @@ mod tests {
         assert_eq!(freq.get("123"), Some(&1));
         assert_eq!(freq.get("a1b2c3"), Some(&1));
         assert_eq!(freq.get("123-456-7890"), Some(&1));
+    }
+
+    #[test]
+    fn test_stop_words_filtered() {
+        // All these are stop words and should return empty
+        assert!(tokenize("the a an is are was were").is_empty());
+
+        // Mix of stop words and regular words
+        assert_eq!(
+            tokenize("the quick brown fox jumps over the lazy dog"),
+            ["quick", "brown", "fox", "jumps", "lazy", "dog"]
+        );
+
+        // Verify stop words don't appear in frequency map
+        let freq = tokenize_and_count_frequencies("the the the cat sat on the mat");
+        assert_eq!(freq.get("the"), None); // "the" is a stop word
+        assert_eq!(freq.get("cat"), Some(&1));
+        assert_eq!(freq.get("sat"), Some(&1));
+        assert_eq!(freq.get("mat"), Some(&1));
     }
 }


### PR DESCRIPTION
Trying to improve perf of BM25 lexical search
- Use cached avg dl and `parking_lot::RwLock` 
- Introduce stopwords