### PR TITLE
Improve disk and memory layout for PostingList

### DIFF
--- a/src/storage/segment/index/text/bm25.rs
+++ b/src/storage/segment/index/text/bm25.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::{StorageError, StorageResult},
-    storage::index::text::posting::PostingListItem,
+    storage::index::text::posting::PostingList,
 };
 
 // Keys for persisting BM25 stats in sled
@@ -81,10 +81,11 @@ impl BM25Scorer {
         self.persist(&stats)
     }
 
-    /// Calculate BM25 scores for documents matching the given posting lists
+    /// Calculate BM25 scores for documents matching the given posting lists.
+    /// Uses SoA layout for cache-efficient iteration.
     pub fn score_documents(
         &self,
-        token_postings: &[(usize, &[PostingListItem])], // (df, posting_list) pairs
+        token_postings: &[(usize, &PostingList)], // (df, posting_list) pairs
     ) -> StorageResult<HashMap<u64, f64>> {
         // Rank completely from memory because it's faster
         let stats = self.bm25_stats.read();
@@ -94,11 +95,13 @@ impl BM25Scorer {
         for (df, posting_list) in token_postings {
             let idf = stats.calculate_idf(*df);
 
-            for item in *posting_list {
-                let tf_component =
-                    stats.calculate_tf_component(item.term_freq, item.doc_id, avg_dl);
+            // Iterate over SoA posting list - doc_ids and term_freqs are contiguous in memory
+            for i in 0..posting_list.len() {
+                let doc_id = posting_list.doc_ids[i];
+                let term_freq = posting_list.term_freqs[i];
+                let tf_component = stats.calculate_tf_component(term_freq, doc_id, avg_dl);
                 let score = idf * tf_component;
-                *docs_with_scores.entry(item.doc_id).or_insert(0.0) += score;
+                *docs_with_scores.entry(doc_id).or_insert(0.0) += score;
             }
         }
 

--- a/src/storage/segment/index/text/mod.rs
+++ b/src/storage/segment/index/text/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 use bm25::BM25Scorer;
-use posting::{merge_sorted_posting_lists, InMemPostings, PostingListItem};
+use posting::{merge_sorted_posting_lists, InMemPostings, PostingList};
 use tokenizer::{tokenize, tokenize_and_count_frequencies};
 
 // Full text search index implementation with posting lists and BM25 ranking
@@ -57,7 +57,7 @@ impl FieldIndexTrait<&str> for TextIndex {
         let terms = tokenize_and_count_frequencies(text);
 
         // Collect all updates first, then apply in batch
-        let mut updates: Vec<(String, Vec<PostingListItem>)> = Vec::with_capacity(terms.len());
+        let mut updates: Vec<(String, PostingList)> = Vec::with_capacity(terms.len());
 
         for (term, term_freq) in &terms {
             let term_key = term.as_bytes();
@@ -69,25 +69,24 @@ impl FieldIndexTrait<&str> for TextIndex {
             } else {
                 self.db
                     .get(term_key)?
-                    .map(|data| PostingListItem::decode_list(&data))
+                    .map(|data| PostingList::decode(&data))
                     .transpose()?
                     .unwrap_or_default()
             };
 
             // Insert maintaining sorted order using binary search
-            let new_item = PostingListItem::new(point_id, *term_freq);
-            match term_posting_list.binary_search_by_key(&point_id, |item| item.doc_id) {
+            match term_posting_list.binary_search(point_id) {
                 Ok(pos) => {
                     // Update existing entry
-                    term_posting_list[pos] = new_item;
+                    term_posting_list.update_term_freq(pos, *term_freq);
                 }
                 Err(pos) => {
-                    term_posting_list.insert(pos, new_item);
+                    term_posting_list.insert(pos, point_id, *term_freq);
                 }
             }
 
             // Store to disk
-            let encoded = PostingListItem::encode_list(&term_posting_list)?;
+            let encoded = term_posting_list.encode()?;
             self.db.insert(term_key, encoded).map_err(|e| {
                 StorageError::ServiceError(format!("Failed to insert into text index tree: {e}"))
             })?;
@@ -126,8 +125,7 @@ impl FieldIndexTrait<&str> for TextIndex {
         }
 
         // Collect posting lists for all query tokens
-        let mut token_postings: Vec<(usize, Vec<PostingListItem>)> =
-            Vec::with_capacity(tokens.len());
+        let mut token_postings: Vec<(usize, PostingList)> = Vec::with_capacity(tokens.len());
 
         if let Some(in_memory_postings) = &self.in_memory_postings {
             let postings = in_memory_postings.read();
@@ -140,7 +138,7 @@ impl FieldIndexTrait<&str> for TextIndex {
             for token in &tokens {
                 let term_key = token.as_bytes();
                 if let Some(data) = self.db.get(term_key)? {
-                    let posting_list = PostingListItem::decode_list(&data)?;
+                    let posting_list = PostingList::decode(&data)?;
                     let df = posting_list.len();
                     token_postings.push((df, posting_list));
                 }
@@ -151,9 +149,9 @@ impl FieldIndexTrait<&str> for TextIndex {
             return Ok(Vec::new());
         }
 
-        let postings_refs: Vec<(usize, &[PostingListItem])> = token_postings
+        let postings_refs: Vec<(usize, &PostingList)> = token_postings
             .iter()
-            .map(|(df, list)| (*df, list.as_slice()))
+            .map(|(df, list)| (*df, list))
             .collect();
 
         let docs_with_scores = self.bm25_scorer.score_documents(&postings_refs)?;
@@ -180,7 +178,8 @@ impl FieldIndexTrait<&str> for TextIndex {
             .collect::<Result<Vec<&str>, StorageError>>()?;
 
         // Build temporary index in memory to batch all postings list updates
-        let mut temp_index: HashMap<String, Vec<PostingListItem>> = HashMap::default();
+        // Use Vec<(doc_id, term_freq)> for easy sorting before conversion to PostingList
+        let mut temp_index: HashMap<String, Vec<(u64, u64)>> = HashMap::default();
         // Track document lengths for incremental BM25 stats updates
         let mut new_doc_lengths: HashMap<u64, u64> = HashMap::default();
 
@@ -193,40 +192,45 @@ impl FieldIndexTrait<&str> for TextIndex {
                 temp_index
                     .entry(term)
                     .or_default()
-                    .push(PostingListItem::new(*point_id, term_freq));
+                    .push((*point_id, term_freq));
             }
         }
 
         // Collect all updates for batch in-memory update
-        let mut all_updates: Vec<(String, Vec<PostingListItem>)> =
-            Vec::with_capacity(temp_index.len());
+        let mut all_updates: Vec<(String, PostingList)> = Vec::with_capacity(temp_index.len());
 
         // Merge temporary index into postings list index
-        for (term, mut new_posting_list) in temp_index {
+        for (term, mut new_entries) in temp_index {
             let term_key = term.as_bytes();
-            let mut posting_list = if let Some(in_memory_postings) = &self.in_memory_postings {
+            let posting_list = if let Some(in_memory_postings) = &self.in_memory_postings {
                 let postings = in_memory_postings.read();
                 postings.get(&term).cloned().unwrap_or_default()
             } else {
                 self.db
                     .get(term_key)?
-                    .map(|data| PostingListItem::decode_list(&data))
+                    .map(|data| PostingList::decode(&data))
                     .transpose()?
                     .unwrap_or_default()
             };
 
-            // Sort new items by doc_id for efficient merge
-            new_posting_list.sort_unstable_by_key(|item| item.doc_id);
+            // Sort new entries by doc_id for efficient merge
+            new_entries.sort_unstable_by_key(|(doc_id, _)| *doc_id);
+
+            // Convert to PostingList
+            let mut new_posting_list = PostingList::with_capacity(new_entries.len());
+            for (doc_id, term_freq) in new_entries {
+                new_posting_list.push(doc_id, term_freq);
+            }
 
             // Merge sorted lists
-            posting_list = merge_sorted_posting_lists(posting_list, new_posting_list);
+            let merged = merge_sorted_posting_lists(posting_list, new_posting_list);
 
-            let encoded = PostingListItem::encode_list(&posting_list)?;
+            let encoded = merged.encode()?;
             self.db.insert(term_key, encoded).map_err(|e| {
                 StorageError::ServiceError(format!("Failed to insert into text index tree: {e}"))
             })?;
 
-            all_updates.push((term, posting_list));
+            all_updates.push((term, merged));
         }
 
         // Update BM25 stats with new document lengths

--- a/src/storage/segment/index/text/posting.rs
+++ b/src/storage/segment/index/text/posting.rs
@@ -35,12 +35,6 @@ impl PostingList {
         self.doc_ids.len()
     }
 
-    /// Check if the posting list is empty
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.doc_ids.is_empty()
-    }
-
     /// Push a new entry to the posting list (must maintain sorted order)
     #[inline]
     pub fn push(&mut self, doc_id: u64, term_freq: u64) {
@@ -65,14 +59,6 @@ impl PostingList {
     #[inline]
     pub fn binary_search(&self, doc_id: u64) -> Result<usize, usize> {
         self.doc_ids.binary_search(&doc_id)
-    }
-
-    /// Iterate over (doc_id, term_freq) pairs
-    pub fn iter(&self) -> impl Iterator<Item = (u64, u64)> + '_ {
-        self.doc_ids
-            .iter()
-            .copied()
-            .zip(self.term_freqs.iter().copied())
     }
 
     /// Encode the posting list using delta encoding for doc_ids and VarInt compression.

--- a/src/storage/segment/index/text/posting.rs
+++ b/src/storage/segment/index/text/posting.rs
@@ -1,18 +1,201 @@
 use std::cmp::Ordering;
 
 use ahash::HashMap;
-use bincode::{Decode, Encode};
 
 use crate::error::{StorageError, StorageResult};
 
-/// In-memory cache for posting lists (optional optimization)
+/// Posting list with Struct-of-Arrays (SoA) layout for better cache efficiency.
+/// Doc IDs are stored separately from term frequencies, allowing faster iteration
+/// when only doc IDs are needed (e.g., for intersection).
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct PostingList {
+    /// Document IDs in sorted order
+    pub doc_ids: Vec<u64>,
+    /// Term frequencies corresponding to each doc_id (same length as doc_ids)
+    pub term_freqs: Vec<u64>,
+}
+
+impl PostingList {
+    /// Create a new empty posting list
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a posting list with pre-allocated capacity
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            doc_ids: Vec::with_capacity(capacity),
+            term_freqs: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Get the number of documents in this posting list (document frequency)
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.doc_ids.len()
+    }
+
+    /// Check if the posting list is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.doc_ids.is_empty()
+    }
+
+    /// Push a new entry to the posting list (must maintain sorted order)
+    #[inline]
+    pub fn push(&mut self, doc_id: u64, term_freq: u64) {
+        self.doc_ids.push(doc_id);
+        self.term_freqs.push(term_freq);
+    }
+
+    /// Insert at a specific position
+    #[inline]
+    pub fn insert(&mut self, pos: usize, doc_id: u64, term_freq: u64) {
+        self.doc_ids.insert(pos, doc_id);
+        self.term_freqs.insert(pos, term_freq);
+    }
+
+    /// Update term frequency at a specific position
+    #[inline]
+    pub fn update_term_freq(&mut self, pos: usize, term_freq: u64) {
+        self.term_freqs[pos] = term_freq;
+    }
+
+    /// Binary search for a doc_id
+    #[inline]
+    pub fn binary_search(&self, doc_id: u64) -> Result<usize, usize> {
+        self.doc_ids.binary_search(&doc_id)
+    }
+
+    /// Iterate over (doc_id, term_freq) pairs
+    pub fn iter(&self) -> impl Iterator<Item = (u64, u64)> + '_ {
+        self.doc_ids
+            .iter()
+            .copied()
+            .zip(self.term_freqs.iter().copied())
+    }
+
+    /// Encode the posting list using delta encoding for doc_ids and VarInt compression.
+    ///
+    /// Format:
+    /// - [varint] number of entries
+    /// - [varint...] delta-encoded doc_ids (first is absolute, rest are deltas)
+    /// - [varint...] term frequencies
+    pub fn encode(&self) -> StorageResult<Vec<u8>> {
+        let mut buf = Vec::new();
+        let len = self.doc_ids.len();
+
+        // Write length
+        encode_varint(&mut buf, len as u64);
+
+        if len == 0 {
+            return Ok(buf);
+        }
+
+        // Write delta-encoded doc_ids
+        let mut prev_doc_id = 0u64;
+        for &doc_id in &self.doc_ids {
+            let delta = doc_id - prev_doc_id;
+            encode_varint(&mut buf, delta);
+            prev_doc_id = doc_id;
+        }
+
+        // Write term frequencies (not delta-encoded, usually small values)
+        for &tf in &self.term_freqs {
+            encode_varint(&mut buf, tf);
+        }
+
+        Ok(buf)
+    }
+
+    /// Decode a posting list from delta-encoded VarInt format
+    pub fn decode(data: &[u8]) -> StorageResult<Self> {
+        let mut pos = 0;
+
+        // Read length
+        let (len, bytes_read) = decode_varint(&data[pos..]).ok_or_else(|| {
+            StorageError::CodecError("Failed to decode posting list length".into())
+        })?;
+        pos += bytes_read;
+        let len = len as usize;
+
+        if len == 0 {
+            return Ok(Self::new());
+        }
+
+        // Read delta-encoded doc_ids
+        let mut doc_ids = Vec::with_capacity(len);
+        let mut prev_doc_id = 0u64;
+        for _ in 0..len {
+            let (delta, bytes_read) = decode_varint(&data[pos..])
+                .ok_or_else(|| StorageError::CodecError("Failed to decode doc_id delta".into()))?;
+            pos += bytes_read;
+            let doc_id = prev_doc_id + delta;
+            doc_ids.push(doc_id);
+            prev_doc_id = doc_id;
+        }
+
+        // Read term frequencies
+        let mut term_freqs = Vec::with_capacity(len);
+        for _ in 0..len {
+            let (tf, bytes_read) = decode_varint(&data[pos..]).ok_or_else(|| {
+                StorageError::CodecError("Failed to decode term frequency".into())
+            })?;
+            pos += bytes_read;
+            term_freqs.push(tf);
+        }
+
+        Ok(Self {
+            doc_ids,
+            term_freqs,
+        })
+    }
+}
+
+/// Encode a u64 as a variable-length integer (VarInt/VLQ encoding).
+/// Uses 7 bits per byte, with MSB indicating continuation.
+#[inline]
+fn encode_varint(buf: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let mut byte = (value & 0x7F) as u8; // 0x7F = b0111_1111. SO it extract 7 bits from the end
+        value >>= 7; // shift value since 7 bits have been extracted
+        if value != 0 {
+            byte |= 0x80; // Set continuation bit. 0x80 = b1000_0000. So it sets the most significant bit to 1.
+        }
+        buf.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+/// Decode a VarInt from a byte slice. Returns (value, bytes_consumed).
+#[inline]
+fn decode_varint(data: &[u8]) -> Option<(u64, usize)> {
+    let mut result = 0u64;
+    let mut shift = 0;
+
+    for (i, &byte) in data.iter().enumerate() {
+        result |= ((byte & 0x7F) as u64) << shift;
+        if byte & 0x80 == 0 {
+            return Some((result, i + 1));
+        }
+        shift += 7;
+        if shift >= 64 {
+            return None; // Overflow
+        }
+    }
+    None // Incomplete
+}
+
+/// In-memory cache for posting lists
 pub struct InMemPostings {
-    postings: HashMap<String, Vec<PostingListItem>>,
+    postings: HashMap<String, PostingList>,
 }
 
 impl InMemPostings {
     pub fn new(tree: &sled::Tree) -> StorageResult<Self> {
-        let mut postings: HashMap<String, Vec<PostingListItem>> = HashMap::default();
+        let mut postings: HashMap<String, PostingList> = HashMap::default();
         for item in tree.iter() {
             let (key, value) = item.map_err(|e| {
                 StorageError::ServiceError(format!("Failed to read text index item: {e}"))
@@ -20,76 +203,58 @@ impl InMemPostings {
             let term = String::from_utf8(key.to_vec()).map_err(|e| {
                 StorageError::CodecError(format!("Failed to decode term {key:?}: {e}"))
             })?;
-            let posting_list = PostingListItem::decode_list(&value)?;
+            let posting_list = PostingList::decode(&value)?;
             postings.insert(term, posting_list);
         }
         Ok(Self { postings })
     }
 
-    pub fn get(&self, term: &str) -> Option<&Vec<PostingListItem>> {
+    pub fn get(&self, term: &str) -> Option<&PostingList> {
         self.postings.get(term)
     }
 
-    pub fn insert(&mut self, term: String, posting_list: Vec<PostingListItem>) {
+    pub fn insert(&mut self, term: String, posting_list: PostingList) {
         self.postings.insert(term, posting_list);
     }
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
-pub struct PostingListItem {
-    pub doc_id: u64,
-    /// Number of times the term appears in the document
-    pub term_freq: u64,
-}
-
-impl PostingListItem {
-    pub fn new(doc_id: u64, term_freq: u64) -> Self {
-        Self { doc_id, term_freq }
-    }
-
-    pub fn encode_list(posting_list: &[Self]) -> StorageResult<Vec<u8>> {
-        bincode::encode_to_vec(posting_list, bincode::config::standard())
-            .map_err(|e| StorageError::CodecError(format!("Failed to encode posting list: {e}")))
-    }
-
-    pub fn decode_list(data: &[u8]) -> StorageResult<Vec<Self>> {
-        bincode::decode_from_slice(data, bincode::config::standard())
-            .map(|(item, _)| item)
-            .map_err(|e| StorageError::CodecError(format!("Failed to decode posting list: {e}")))
-    }
-}
-
 /// Merge two sorted posting lists, preferring items from `new` when doc_ids collide
-pub fn merge_sorted_posting_lists(
-    existing: Vec<PostingListItem>,
-    new: Vec<PostingListItem>,
-) -> Vec<PostingListItem> {
-    let mut result = Vec::with_capacity(existing.len() + new.len());
+pub fn merge_sorted_posting_lists(existing: PostingList, new: PostingList) -> PostingList {
+    let mut result = PostingList::with_capacity(existing.len() + new.len());
     let mut i = 0;
     let mut j = 0;
 
     while i < existing.len() && j < new.len() {
-        match existing[i].doc_id.cmp(&new[j].doc_id) {
+        match existing.doc_ids[i].cmp(&new.doc_ids[j]) {
             Ordering::Less => {
-                result.push(existing[i].clone());
+                result.push(existing.doc_ids[i], existing.term_freqs[i]);
                 i += 1;
             }
             Ordering::Greater => {
-                result.push(new[j].clone());
+                result.push(new.doc_ids[j], new.term_freqs[j]);
                 j += 1;
             }
             Ordering::Equal => {
                 // New takes precedence (update case)
-                result.push(new[j].clone());
+                result.push(new.doc_ids[j], new.term_freqs[j]);
                 i += 1;
                 j += 1;
             }
         }
     }
 
-    // Append remaining
-    result.extend_from_slice(&existing[i..]);
-    result.extend_from_slice(&new[j..]);
+    // Append remaining from existing
+    while i < existing.len() {
+        result.push(existing.doc_ids[i], existing.term_freqs[i]);
+        i += 1;
+    }
+
+    // Append remaining from new
+    while j < new.len() {
+        result.push(new.doc_ids[j], new.term_freqs[j]);
+        j += 1;
+    }
+
     result
 }
 
@@ -98,45 +263,93 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_merge_sorted_posting_lists() {
-        let existing = vec![
-            PostingListItem::new(1, 2),
-            PostingListItem::new(3, 1),
-            PostingListItem::new(5, 3),
-        ];
-        let new = vec![
-            PostingListItem::new(2, 1),
-            PostingListItem::new(3, 5), // Updated
-            PostingListItem::new(4, 2),
-        ];
+    fn test_varint_encoding() {
+        // Test small values (1 byte)
+        let mut buf = Vec::new();
+        encode_varint(&mut buf, 0);
+        assert_eq!(buf, vec![0]);
 
-        let merged = merge_sorted_posting_lists(existing, new);
-        assert_eq!(merged.len(), 5);
-        assert_eq!(merged[0].doc_id, 1);
-        assert_eq!(merged[1].doc_id, 2);
-        assert_eq!(merged[2].doc_id, 3);
-        assert_eq!(merged[2].term_freq, 5); // Should be updated value
-        assert_eq!(merged[3].doc_id, 4);
-        assert_eq!(merged[4].doc_id, 5);
+        buf.clear();
+        encode_varint(&mut buf, 127);
+        assert_eq!(buf, vec![127]);
+
+        // Test 2-byte value
+        buf.clear();
+        encode_varint(&mut buf, 128);
+        assert_eq!(buf, vec![0x80, 0x01]);
+
+        buf.clear();
+        encode_varint(&mut buf, 300);
+        assert_eq!(buf, vec![0xAC, 0x02]); // 300 = 0b100101100 -> [0b10101100, 0b00000010]
+
+        // Test round-trip for various values
+        for value in [0, 1, 127, 128, 255, 256, 16383, 16384, u64::MAX] {
+            buf.clear();
+            encode_varint(&mut buf, value);
+            let (decoded, _) = decode_varint(&buf).unwrap();
+            assert_eq!(decoded, value, "Round-trip failed for {value}");
+        }
     }
 
     #[test]
-    fn test_posting_list_encoding_size() {
-        let mut posting_list = vec![];
+    fn test_posting_list_encoding() {
+        // Empty list
+        let list = PostingList::new();
+        let encoded = list.encode().unwrap();
+        let decoded = PostingList::decode(&encoded).unwrap();
+        assert_eq!(decoded, list);
 
-        let encoded = PostingListItem::encode_list(&posting_list).unwrap();
-        assert_eq!(encoded, vec![0]);
+        // Single entry
+        let mut list = PostingList::new();
+        list.push(5, 3);
+        let encoded = list.encode().unwrap();
+        let decoded = PostingList::decode(&encoded).unwrap();
+        assert_eq!(decoded, list);
 
-        posting_list.push(PostingListItem::new(5, 8));
-        let encoded = PostingListItem::encode_list(&posting_list).unwrap();
-        assert_eq!(encoded, vec![1, 5, 8]);
+        // Multiple entries with sequential doc_ids (good delta compression)
+        let mut list = PostingList::new();
+        list.push(100, 2);
+        list.push(105, 1); // delta = 5
+        list.push(108, 4); // delta = 3
+        list.push(200, 1); // delta = 92
+        let encoded = list.encode().unwrap();
+        let decoded = PostingList::decode(&encoded).unwrap();
+        assert_eq!(decoded, list);
 
-        posting_list.push(PostingListItem::new(55, 3));
-        posting_list.push(PostingListItem::new(3, 1));
-        let encoded = PostingListItem::encode_list(&posting_list).unwrap();
-        assert_eq!(encoded, vec![3, 5, 8, 55, 3, 3, 1]); // first byte is the length of the list
+        // Verify compression benefit: deltas [100, 5, 3, 92] use fewer bytes than [100, 105, 108, 200]
+        assert!(encoded.len() < 4 * 8 * 2); // Much less than 8 bytes * 4 entries * 2 arrays
+    }
 
-        let decoded = PostingListItem::decode_list(&encoded).unwrap();
-        assert_eq!(decoded, posting_list);
+    #[test]
+    fn test_merge_sorted_posting_lists() {
+        let mut existing = PostingList::new();
+        existing.push(1, 2);
+        existing.push(3, 1);
+        existing.push(5, 3);
+
+        let mut new = PostingList::new();
+        new.push(2, 1);
+        new.push(3, 5); // Updated
+        new.push(4, 2);
+
+        let merged = merge_sorted_posting_lists(existing, new);
+        assert_eq!(merged.len(), 5);
+        assert_eq!(merged.doc_ids, vec![1, 2, 3, 4, 5]);
+        assert_eq!(merged.term_freqs[2], 5); // Should be updated value from new
+    }
+
+    #[test]
+    fn test_posting_list_binary_search() {
+        let mut list = PostingList::new();
+        list.push(10, 1);
+        list.push(20, 2);
+        list.push(30, 3);
+
+        assert_eq!(list.binary_search(10), Ok(0));
+        assert_eq!(list.binary_search(20), Ok(1));
+        assert_eq!(list.binary_search(30), Ok(2));
+        assert_eq!(list.binary_search(15), Err(1)); // Would insert at position 1
+        assert_eq!(list.binary_search(5), Err(0)); // Would insert at position 0
+        assert_eq!(list.binary_search(35), Err(3)); // Would insert at position 3
     }
 }


### PR DESCRIPTION
- Use Struct of Arrays for `PostingList` instead of Array of Structs for better cache utilization when iterating.
- Use Delta encoding like [exa.ai](https://exa.ai/blog/bm25-optimization)

